### PR TITLE
Add link to GoDoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # d.velop cloud SDK for Go
 [![Build Status](https://travis-ci.com/d-velop/dvelop-sdk-go.svg?branch=master)](https://travis-ci.com/d-velop/dvelop-sdk-go)
+[![Godoc](https://godoc.org/github.com/d-velop/dvelop-sdk-go?status.svg)](https://godoc.org/github.com/d-velop/dvelop-sdk-go)
 
 This is the official SDK to build Apps for [d.velop cloud](https://www.d-velop.de/cloud/) using 
 the [Go Progamming Language](https://golang.org/).


### PR DESCRIPTION
Add a badge with the link to the GoDoc website to easily find and browse the documentation of this SDK.