### PR TITLE
Fix/format imports with goimports

### DIFF
--- a/contentnegotiation/mediatype/mediatype_test.go
+++ b/contentnegotiation/mediatype/mediatype_test.go
@@ -1,8 +1,9 @@
 package mediatype_test
 
 import (
-	"github.com/d-velop/dvelop-sdk-go/contentnegotiation/mediatype"
 	"testing"
+
+	"github.com/d-velop/dvelop-sdk-go/contentnegotiation/mediatype"
 )
 
 func TestRequestedTypeNotSupported_ReturnsErrorNotSupported(t *testing.T) {

--- a/idp/authmiddleware.go
+++ b/idp/authmiddleware.go
@@ -6,16 +6,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/d-velop/dvelop-sdk-go/idp/scim"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"regexp"
-	"time"
-
-	"github.com/patrickmn/go-cache"
 	"strconv"
 	"strings"
+	"time"
+
+	"github.com/d-velop/dvelop-sdk-go/idp/scim"
+	"github.com/patrickmn/go-cache"
 )
 
 type contextKey string

--- a/idp/authmiddleware_test.go
+++ b/idp/authmiddleware_test.go
@@ -12,8 +12,10 @@ import (
 	"reflect"
 	"regexp"
 	"testing"
-
 	"time"
+
+	"github.com/d-velop/dvelop-sdk-go/idp"
+	"github.com/d-velop/dvelop-sdk-go/idp/scim"
 )
 
 func TestGetRequestWithFalseAuthorizationType_RedirectsToIdp(t *testing.T) {

--- a/idp/authmiddleware_test.go
+++ b/idp/authmiddleware_test.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/d-velop/dvelop-sdk-go/idp"
-	"github.com/d-velop/dvelop-sdk-go/idp/scim"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -27,7 +25,7 @@ func TestGetRequestWithFalseAuthorizationType_RedirectsToIdp(t *testing.T) {
 	req.Header.Set("Authorization", "Basic adadbk")
 	handlerSpy := handlerSpy{}
 
-	idp.HandleAuth(nil, nil,false, log, log)(&handlerSpy).ServeHTTP(responseSpy, req)
+	idp.HandleAuth(nil, nil, false, log, log)(&handlerSpy).ServeHTTP(responseSpy, req)
 
 	if err := responseSpy.assertStatusCodeIs(http.StatusFound); err != nil {
 		t.Error(err)
@@ -49,7 +47,7 @@ func TestGetRequestWithFalseCookie_RedirectsToIdp(t *testing.T) {
 	req.AddCookie(&http.Cookie{Name: "AnyCookie", Value: "adadbk"})
 	handlerSpy := handlerSpy{}
 
-	idp.HandleAuth(nil, nil,false, log, log)(&handlerSpy).ServeHTTP(responseSpy, req)
+	idp.HandleAuth(nil, nil, false, log, log)(&handlerSpy).ServeHTTP(responseSpy, req)
 
 	if err := responseSpy.assertStatusCodeIs(http.StatusFound); err != nil {
 		t.Error(err)
@@ -69,7 +67,7 @@ func TestHeadRequestWithoutAuthorizationInfos_RedirectsToIdp(t *testing.T) {
 	}
 	responseSpy := responseSpy{httptest.NewRecorder()}
 	handlerSpy := &handlerSpy{}
-	idp.HandleAuth(nil, nil,false, log, log)(handlerSpy).ServeHTTP(responseSpy, req)
+	idp.HandleAuth(nil, nil, false, log, log)(handlerSpy).ServeHTTP(responseSpy, req)
 
 	if err := responseSpy.assertStatusCodeIs(http.StatusFound); err != nil {
 		t.Error(err)
@@ -89,7 +87,7 @@ func TestPostRequestWithoutAuthorizationInfos_ReturnsStatus401(t *testing.T) {
 	}
 	responseSpy := responseSpy{httptest.NewRecorder()}
 	handlerSpy := &handlerSpy{}
-	idp.HandleAuth(nil, nil,false, log, log)(handlerSpy).ServeHTTP(responseSpy, req)
+	idp.HandleAuth(nil, nil, false, log, log)(handlerSpy).ServeHTTP(responseSpy, req)
 
 	if err := responseSpy.assertStatusCodeIs(http.StatusUnauthorized); err != nil {
 		t.Error(err)
@@ -109,7 +107,7 @@ func TestPutRequestWithoutAuthorizationInfos_ReturnsStatus401(t *testing.T) {
 	}
 	responseSpy := responseSpy{httptest.NewRecorder()}
 	handlerSpy := &handlerSpy{}
-	idp.HandleAuth(nil, nil,false, log, log)(handlerSpy).ServeHTTP(responseSpy, req)
+	idp.HandleAuth(nil, nil, false, log, log)(handlerSpy).ServeHTTP(responseSpy, req)
 
 	if err := responseSpy.assertStatusCodeIs(http.StatusUnauthorized); err != nil {
 		t.Error(err)
@@ -129,7 +127,7 @@ func TestDeleteRequestWithoutAuthorizationInfos_ReturnsStatus401(t *testing.T) {
 	}
 	responseSpy := responseSpy{httptest.NewRecorder()}
 	handlerSpy := &handlerSpy{}
-	idp.HandleAuth(nil, nil,false, log, log)(handlerSpy).ServeHTTP(responseSpy, req)
+	idp.HandleAuth(nil, nil, false, log, log)(handlerSpy).ServeHTTP(responseSpy, req)
 
 	if err := responseSpy.assertStatusCodeIs(http.StatusUnauthorized); err != nil {
 		t.Error(err)
@@ -149,7 +147,7 @@ func TestPatchRequestWithoutAuthorizationInfos_ReturnsStatus401(t *testing.T) {
 	}
 	responseSpy := responseSpy{httptest.NewRecorder()}
 	handlerSpy := &handlerSpy{}
-	idp.HandleAuth(nil, nil,false, log, log)(handlerSpy).ServeHTTP(responseSpy, req)
+	idp.HandleAuth(nil, nil, false, log, log)(handlerSpy).ServeHTTP(responseSpy, req)
 
 	if err := responseSpy.assertStatusCodeIs(http.StatusUnauthorized); err != nil {
 		t.Error(err)
@@ -175,10 +173,10 @@ func TestRequestWithBearerAuthorization_PopulatesContextWithPrincipalAndAuthsess
 	principal := scim.Principal{Id: "9bbbf1b6-017a-449a-ad5f-9723d28223e1"}
 	req.Header.Set("Authorization", "Bearer "+authSessionId)
 	handlerSpy := handlerSpy{}
-	idpStub := newIdpStub(map[string]scim.Principal{authSessionId: principal},nil)
+	idpStub := newIdpStub(map[string]scim.Principal{authSessionId: principal}, nil)
 	defer idpStub.Close()
 
-	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"),false, log, log)(&handlerSpy).ServeHTTP(httptest.NewRecorder(), req)
+	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"), false, log, log)(&handlerSpy).ServeHTTP(httptest.NewRecorder(), req)
 
 	if err := handlerSpy.assertAuthSessionIdIs(authSessionId); err != nil {
 		t.Error(err)
@@ -197,10 +195,10 @@ func TestRequestWithLowerCaseBearerAuthorization_PopulatesContextWithPrincipalAn
 	principal := scim.Principal{Id: "9bbbf1b6-017a-449a-ad5f-9723d28223e2"}
 	req.Header.Set("Authorization", "bearer "+authSessionId)
 	handlerSpy := handlerSpy{}
-	idpStub := newIdpStub(map[string]scim.Principal{authSessionId: principal},nil)
+	idpStub := newIdpStub(map[string]scim.Principal{authSessionId: principal}, nil)
 	defer idpStub.Close()
 
-	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"), false,log, log)(&handlerSpy).ServeHTTP(httptest.NewRecorder(), req)
+	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"), false, log, log)(&handlerSpy).ServeHTTP(httptest.NewRecorder(), req)
 
 	if err := handlerSpy.assertAuthSessionIdIs(authSessionId); err != nil {
 		t.Error(err)
@@ -220,10 +218,10 @@ func TestRequestWithAuthSessionIdCookie_PopulatesContextWithPrincipalAndAuthsess
 	principal := scim.Principal{Id: "9bbbf1b6-017a-449a-ad5f-9723d28223e3"}
 	req.AddCookie(&http.Cookie{Name: "AuthSessionId", Value: base64EncodedAuthSessionId})
 	handlerSpy := handlerSpy{}
-	idpStub := newIdpStub(map[string]scim.Principal{authSessionId: principal},nil)
+	idpStub := newIdpStub(map[string]scim.Principal{authSessionId: principal}, nil)
 	defer idpStub.Close()
 
-	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"), false,log, log)(&handlerSpy).ServeHTTP(httptest.NewRecorder(), req)
+	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"), false, log, log)(&handlerSpy).ServeHTTP(httptest.NewRecorder(), req)
 
 	if err := handlerSpy.assertAuthSessionIdIs(authSessionId); err != nil {
 		t.Error(err)
@@ -243,11 +241,11 @@ func TestRequestWithBadUrlEncodedAuthSessionIdCookie_ReturnsStatus500(t *testing
 	principal := scim.Principal{Id: "9bbbf1b6-017a-449a-ad5f-9723d28223e3"}
 	req.AddCookie(&http.Cookie{Name: "AuthSessionId", Value: base64EncodedAuthSessionId})
 	handlerSpy := handlerSpy{}
-	idpStub := newIdpStub(map[string]scim.Principal{authSessionId: principal},nil)
+	idpStub := newIdpStub(map[string]scim.Principal{authSessionId: principal}, nil)
 	defer idpStub.Close()
 	spy := responseSpy{httptest.NewRecorder()}
 
-	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"),false, log, log)(&handlerSpy).ServeHTTP(spy, req)
+	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"), false, log, log)(&handlerSpy).ServeHTTP(spy, req)
 
 	if err := spy.assertStatusCodeIs(http.StatusInternalServerError); err != nil {
 		t.Error(err)
@@ -268,10 +266,10 @@ func TestRequestWithBearerTokenAndCookie_PopulatesContextUsingBearerToken(t *tes
 	req.AddCookie(&http.Cookie{Name: "AuthSessionId", Value: cookieValue})
 	req.Header.Set("Authorization", "Bearer "+authSessionId)
 	handlerSpy := handlerSpy{}
-	idpStub := newIdpStub(map[string]scim.Principal{authSessionId: principal},nil)
+	idpStub := newIdpStub(map[string]scim.Principal{authSessionId: principal}, nil)
 	defer idpStub.Close()
 
-	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"), false,log, log)(&handlerSpy).ServeHTTP(httptest.NewRecorder(), req)
+	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"), false, log, log)(&handlerSpy).ServeHTTP(httptest.NewRecorder(), req)
 
 	if err := handlerSpy.assertAuthSessionIdIs(authSessionId); err != nil {
 		t.Error(err)
@@ -297,7 +295,7 @@ func TestRequestWithBadTokenAndExternalValidationIsNotAllowed_RedirectsToIdp(t *
 	defer idpStub.Close()
 	spy := responseSpy{httptest.NewRecorder()}
 
-	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"),false, log, log)(&handlerSpy).ServeHTTP(spy, req)
+	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"), false, log, log)(&handlerSpy).ServeHTTP(spy, req)
 
 	if err := spy.assertStatusCodeIs(http.StatusFound); err != nil {
 		t.Error(err)
@@ -326,7 +324,7 @@ func TestRequestWithBadTokenAndExternalValidationIsAllowed_RedirectsToIdp(t *tes
 	defer idpStub.Close()
 	spy := responseSpy{httptest.NewRecorder()}
 
-	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"),true, log, log)(&handlerSpy).ServeHTTP(spy, req)
+	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"), true, log, log)(&handlerSpy).ServeHTTP(spy, req)
 
 	if err := spy.assertStatusCodeIs(http.StatusFound); err != nil {
 		t.Error(err)
@@ -348,11 +346,11 @@ func TestGetSystemBaseUriFromCtxReturnsError_ReturnsStatus500(t *testing.T) {
 	principal := scim.Principal{Id: "9bbbf1b6-017a-449a-ad5f-9723d28223e4"}
 	req.Header.Set("Authorization", "Bearer "+authSessionId)
 	handlerSpy := handlerSpy{}
-	idpStub := newIdpStub(map[string]scim.Principal{authSessionId: principal},nil)
+	idpStub := newIdpStub(map[string]scim.Principal{authSessionId: principal}, nil)
 	defer idpStub.Close()
 	spy := responseSpy{httptest.NewRecorder()}
 
-	idp.HandleAuth(func(ctx context.Context) (string, error) { return "", errors.New("any error") }, returnFromCtx("1"),false, log, log)(&handlerSpy).ServeHTTP(spy, req)
+	idp.HandleAuth(func(ctx context.Context) (string, error) { return "", errors.New("any error") }, returnFromCtx("1"), false, log, log)(&handlerSpy).ServeHTTP(spy, req)
 
 	if err := spy.assertStatusCodeIs(http.StatusInternalServerError); err != nil {
 		t.Error(err)
@@ -371,11 +369,11 @@ func TestGetTenantIdFromCtxReturnsError_ReturnsStatus500(t *testing.T) {
 	principal := scim.Principal{Id: "9bbbf1b6-017a-449a-ad5f-9723d28223e4"}
 	req.Header.Set("Authorization", "Bearer "+authSessionId)
 	handlerSpy := handlerSpy{}
-	idpStub := newIdpStub(map[string]scim.Principal{authSessionId: principal},nil)
+	idpStub := newIdpStub(map[string]scim.Principal{authSessionId: principal}, nil)
 	defer idpStub.Close()
 	spy := responseSpy{httptest.NewRecorder()}
 
-	idp.HandleAuth(returnFromCtx(idpStub.URL), func(ctx context.Context) (string, error) { return "", errors.New("any error") }, false,log, log)(&handlerSpy).ServeHTTP(spy, req)
+	idp.HandleAuth(returnFromCtx(idpStub.URL), func(ctx context.Context) (string, error) { return "", errors.New("any error") }, false, log, log)(&handlerSpy).ServeHTTP(spy, req)
 
 	if err := spy.assertStatusCodeIs(http.StatusInternalServerError); err != nil {
 		t.Error(err)
@@ -400,7 +398,7 @@ func TestIdPReturnsStatus500_ReturnsStatus500(t *testing.T) {
 	defer idpStub.Close()
 	spy := responseSpy{httptest.NewRecorder()}
 
-	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"), false,log, log)(&handlerSpy).ServeHTTP(spy, req)
+	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"), false, log, log)(&handlerSpy).ServeHTTP(spy, req)
 
 	if err := spy.assertStatusCodeIs(http.StatusInternalServerError); err != nil {
 		t.Error(err)
@@ -426,7 +424,7 @@ func TestIdPReturnsMalformedJson_ReturnsStatus500(t *testing.T) {
 	defer idpStub.Close()
 	spy := responseSpy{httptest.NewRecorder()}
 
-	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"), false,log, log)(&handlerSpy).ServeHTTP(spy, req)
+	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"), false, log, log)(&handlerSpy).ServeHTTP(spy, req)
 
 	if err := spy.assertStatusCodeIs(http.StatusInternalServerError); err != nil {
 		t.Error(err)
@@ -452,7 +450,7 @@ func TestIdPReturnsPrincipalWithEmptyId_ReturnsStatus500(t *testing.T) {
 	defer idpStub.Close()
 	spy := responseSpy{httptest.NewRecorder()}
 
-	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"), false,log, log)(&handlerSpy).ServeHTTP(spy, req)
+	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"), false, log, log)(&handlerSpy).ServeHTTP(spy, req)
 
 	if err := spy.assertStatusCodeIs(http.StatusInternalServerError); err != nil {
 		t.Error(err)
@@ -481,9 +479,9 @@ func TestUserIsCachedAndCacheEntryIsNotExpired_ReturnsCachedEntry(t *testing.T) 
 	}))
 	defer idpStub.Close()
 
-	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"), false,log, log)(&handlerSpy).ServeHTTP(httptest.NewRecorder(), req)
+	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"), false, log, log)(&handlerSpy).ServeHTTP(httptest.NewRecorder(), req)
 	time.Sleep(1 * time.Nanosecond)
-	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"),false, log, log)(&handlerSpy).ServeHTTP(httptest.NewRecorder(), req)
+	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"), false, log, log)(&handlerSpy).ServeHTTP(httptest.NewRecorder(), req)
 
 	if idpCalled != 1 {
 		t.Errorf("IdP has been called %v times but expected %v times", idpCalled, 1)
@@ -512,9 +510,9 @@ func TestUserIsCachedButCacheEntryIsExpired_CallsIdp(t *testing.T) {
 	}))
 	defer idpStub.Close()
 
-	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"), false,log, log)(&handlerSpy).ServeHTTP(httptest.NewRecorder(), req)
+	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"), false, log, log)(&handlerSpy).ServeHTTP(httptest.NewRecorder(), req)
 	time.Sleep(1 * time.Second)
-	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"), false,log, log)(&handlerSpy).ServeHTTP(httptest.NewRecorder(), req)
+	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"), false, log, log)(&handlerSpy).ServeHTTP(httptest.NewRecorder(), req)
 
 	if idpCalled != 2 {
 		t.Errorf("IdP has been called %v times but expected %v times", idpCalled, 2)
@@ -533,10 +531,10 @@ func TestUserIsCachedForDifferentTenant_CallsIdp(t *testing.T) {
 	}
 	principalT1 := scim.Principal{Id: "9bbbf1b6-017a-449a-ad5f-9723d28223e7"}
 	reqTenant1.Header.Set("Authorization", "Bearer "+authSessionId)
-	idpStub1 := newIdpStub(map[string]scim.Principal{authSessionId: principalT1},nil)
+	idpStub1 := newIdpStub(map[string]scim.Principal{authSessionId: principalT1}, nil)
 	defer idpStub1.Close()
 	handlerSpy1 := handlerSpy{}
-	idp.HandleAuth(returnFromCtx(idpStub1.URL), returnFromCtx("1"), false,log, log)(&handlerSpy1).ServeHTTP(httptest.NewRecorder(), reqTenant1)
+	idp.HandleAuth(returnFromCtx(idpStub1.URL), returnFromCtx("1"), false, log, log)(&handlerSpy1).ServeHTTP(httptest.NewRecorder(), reqTenant1)
 
 	if err := handlerSpy1.assertPrincipalIs(principalT1); err != nil {
 		t.Error(err)
@@ -548,17 +546,17 @@ func TestUserIsCachedForDifferentTenant_CallsIdp(t *testing.T) {
 	}
 	principalT2 := scim.Principal{Id: "0bbbf1b6-017a-449a-ad5f-9723d28223e7"}
 	reqTenant2.Header.Set("Authorization", "Bearer "+authSessionId)
-	idpStub2 := newIdpStub(map[string]scim.Principal{authSessionId: principalT2},nil)
+	idpStub2 := newIdpStub(map[string]scim.Principal{authSessionId: principalT2}, nil)
 	defer idpStub2.Close()
 	handlerSpy2 := handlerSpy{}
-	idp.HandleAuth(returnFromCtx(idpStub2.URL), returnFromCtx("2"), false,log, log)(&handlerSpy2).ServeHTTP(httptest.NewRecorder(), reqTenant2)
+	idp.HandleAuth(returnFromCtx(idpStub2.URL), returnFromCtx("2"), false, log, log)(&handlerSpy2).ServeHTTP(httptest.NewRecorder(), reqTenant2)
 
 	if err := handlerSpy2.assertPrincipalIs(principalT2); err != nil {
 		t.Error(err)
 	}
 }
 
-func TestRequestAsExternalUserAndExternalUserValidationIsNotAllowed_ReturnsStatus403(t *testing.T){
+func TestRequestAsExternalUserAndExternalUserValidationIsNotAllowed_ReturnsStatus403(t *testing.T) {
 	req, err := http.NewRequest("GET", "/myresource/subresource?query1=abc&query2=123", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -566,7 +564,7 @@ func TestRequestAsExternalUserAndExternalUserValidationIsNotAllowed_ReturnsStatu
 	const authSessionId = "hXGxJeb0q+/fS8biFi8FE7TovJPPEPyzlDxT6bh5p5pHA/x7CEi1w9egVhEMz8IWhrtvJRFnkSqJnLr61cOKf/i5eWuu7Duh+OTtTjMOt9w=&Bnh4NNU90wH_OVlgbzbdZOEu1aSuPlbUctiCdYTonZ3Ap_Zd3bVL79I-dPdHf4OOgO8NKEdqyLsqc8RhAOreXgJqXuqsreeI"
 	req.Header.Set("Authorization", "Bearer "+authSessionId)
 	handlerSpy := handlerSpy{}
-	idpStub := newIdpStub(nil, map[string]scim.Principal{authSessionId:{Emails: []scim.UserValue{{"info@d-velop.de"}},Groups: []scim.UserGroup{{Value:"3E093BE5-CCCE-435D-99F8-544656B98681"}}}})
+	idpStub := newIdpStub(nil, map[string]scim.Principal{authSessionId: {Emails: []scim.UserValue{{"info@d-velop.de"}}, Groups: []scim.UserGroup{{Value: "3E093BE5-CCCE-435D-99F8-544656B98681"}}}})
 	defer idpStub.Close()
 	spy := responseSpy{httptest.NewRecorder()}
 
@@ -579,19 +577,19 @@ func TestRequestAsExternalUserAndExternalUserValidationIsNotAllowed_ReturnsStatu
 	}
 }
 
-func TestRequestAsExternalUserAndExternalValidationIsAllowed_PopulatesContextWithPrincipalAndAuthsession(t *testing.T){
+func TestRequestAsExternalUserAndExternalValidationIsAllowed_PopulatesContextWithPrincipalAndAuthsession(t *testing.T) {
 	req, err := http.NewRequest("GET", "/myresource/subresource?query1=abc&query2=123", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	const authSessionId = "1XGxJeb0q+/fS8biFi8FE7TovJPPEPyzlDxT6bh5p5pHA/x7CEi1w9egVhEMz8IWhrtvJRFnkSqJnLr61cOKf/i5eWuu7Duh+OTtTjMOt9w=&Bnh4NNU90wH_OVlgbzbdZOEu1aSuPlbUctiCdYTonZ3Ap_Zd3bVL79I-dPdHf4OOgO8NKEdqyLsqc8RhAOreXgJqXuqsreeI"
-	principal := scim.Principal{Emails: []scim.UserValue{{"info@d-velop.de"}},Groups: []scim.UserGroup{{Value:"3E093BE5-CCCE-435D-99F8-544656B98681"}}}
+	principal := scim.Principal{Emails: []scim.UserValue{{"info@d-velop.de"}}, Groups: []scim.UserGroup{{Value: "3E093BE5-CCCE-435D-99F8-544656B98681"}}}
 	req.Header.Set("Authorization", "Bearer "+authSessionId)
 	handlerSpy := new(handlerSpy)
-	idpStub := newIdpStub(nil, map[string]scim.Principal{authSessionId:principal})
+	idpStub := newIdpStub(nil, map[string]scim.Principal{authSessionId: principal})
 	defer idpStub.Close()
 
-	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"),true, log, log)(handlerSpy).ServeHTTP(httptest.NewRecorder(), req)
+	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"), true, log, log)(handlerSpy).ServeHTTP(httptest.NewRecorder(), req)
 
 	if err := handlerSpy.assertAuthSessionIdIs(authSessionId); err != nil {
 		t.Error(err)
@@ -601,7 +599,7 @@ func TestRequestAsExternalUserAndExternalValidationIsAllowed_PopulatesContextWit
 	}
 }
 
-func TestRequestAsInternalUserAndExternalValidationIsAllowed_PopulatesContextWithPrincipalAndAuthsession(t *testing.T){
+func TestRequestAsInternalUserAndExternalValidationIsAllowed_PopulatesContextWithPrincipalAndAuthsession(t *testing.T) {
 	req, err := http.NewRequest("GET", "/myresource/subresource?query1=abc&query2=123", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -610,10 +608,10 @@ func TestRequestAsInternalUserAndExternalValidationIsAllowed_PopulatesContextWit
 	principal := scim.Principal{Id: "7bbbf1b6-017a-449a-ad5f-9723d28223e1"}
 	req.Header.Set("Authorization", "Bearer "+authSessionId)
 	handlerSpy := new(handlerSpy)
-	idpStub := newIdpStub( map[string]scim.Principal{authSessionId:principal},nil)
+	idpStub := newIdpStub(map[string]scim.Principal{authSessionId: principal}, nil)
 	defer idpStub.Close()
 
-	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"),true, log, log)(handlerSpy).ServeHTTP(httptest.NewRecorder(), req)
+	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"), true, log, log)(handlerSpy).ServeHTTP(httptest.NewRecorder(), req)
 
 	if err := handlerSpy.assertAuthSessionIdIs(authSessionId); err != nil {
 		t.Error(err)
@@ -641,8 +639,8 @@ func TestIdpSendsNoCacheHeader_CallsIdp(t *testing.T) {
 	}))
 	defer idpStub.Close()
 
-	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"), false,log, log)(&handlerSpy).ServeHTTP(httptest.NewRecorder(), req)
-	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"), false,log, log)(&handlerSpy).ServeHTTP(httptest.NewRecorder(), req)
+	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"), false, log, log)(&handlerSpy).ServeHTTP(httptest.NewRecorder(), req)
+	idp.HandleAuth(returnFromCtx(idpStub.URL), returnFromCtx("1"), false, log, log)(&handlerSpy).ServeHTTP(httptest.NewRecorder(), req)
 
 	if idpCalled != 2 {
 		t.Errorf("IdP has been called %v times but expected %v times", idpCalled, 2)
@@ -692,7 +690,7 @@ func TestGetRequestWithoutAuthorizationInfosWithAcceptHeader(t *testing.T) {
 			responseSpy := responseSpy{httptest.NewRecorder()}
 
 			handlerSpy := &handlerSpy{}
-			idp.HandleAuth(nil, nil,false, log, log)(handlerSpy).ServeHTTP(responseSpy, req)
+			idp.HandleAuth(nil, nil, false, log, log)(handlerSpy).ServeHTTP(responseSpy, req)
 
 			if handlerSpy.hasBeenCalled {
 				t.Error("inner handler should not have been called")

--- a/idp/scim/user_test.go
+++ b/idp/scim/user_test.go
@@ -2,9 +2,10 @@ package scim_test
 
 import (
 	"encoding/json"
-	"github.com/d-velop/dvelop-sdk-go/idp/scim"
 	"reflect"
 	"testing"
+
+	"github.com/d-velop/dvelop-sdk-go/idp/scim"
 )
 
 const donaldDuckJson = `{"id":"146bc69e-1edf-40f6-bf68-849906998838","userName":"d-velop\\donald","name":{"familyName":"Duck","givenName":"Donald"},"displayName":"Donald Duck","title":"Scrum Duck","emails":[{"value":"donal.duck@entenhausen.de"}],"phoneNumbers":[{"value":"+49 1235 9455-1234"}],"groups":[{"value":"d84b34da-c60e-495e-9a0d-59507630be3a","display":"Developer"},{"value":"759eaed7-4f4e-4fac-a5ef-49f03d0811a1","display":"Scrum People"}],"photos":[{"value":"/identityprovider/scim/photo/donaldbig"}]}`

--- a/lambda/server_test.go
+++ b/lambda/server_test.go
@@ -2,9 +2,9 @@ package lambda_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"fmt"
-	"github.com/d-velop/dvelop-sdk-go/lambda"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -12,8 +12,8 @@ import (
 	"reflect"
 	"testing"
 
-	"context"
 	"github.com/aws/aws-lambda-go/events"
+	"github.com/d-velop/dvelop-sdk-go/lambda"
 )
 
 func invokeAdaptorFunc(t *testing.T, evt *events.APIGatewayProxyRequest) *testresult {

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -3,9 +3,10 @@ package log_test
 import (
 	"bytes"
 	"context"
-	"github.com/d-velop/dvelop-sdk-go/log"
 	"regexp"
 	"testing"
+
+	"github.com/d-velop/dvelop-sdk-go/log"
 )
 
 func TestMessageEndsWithNewline_Print_WritesMessageWithNewline(t *testing.T) {

--- a/log/syslog/syslog_test.go
+++ b/log/syslog/syslog_test.go
@@ -3,10 +3,11 @@ package syslog_test
 import (
 	"context"
 	"fmt"
-	"github.com/d-velop/dvelop-sdk-go/log/syslog"
 	"os"
 	"regexp"
 	"testing"
+
+	"github.com/d-velop/dvelop-sdk-go/log/syslog"
 )
 
 func TestWriteHeaderInfoFunc_WritesAppnameAndInfoSeverity(t *testing.T) {

--- a/requestid/requestidmiddleware.go
+++ b/requestid/requestidmiddleware.go
@@ -24,8 +24,9 @@ package requestid
 import (
 	"context"
 	"errors"
-	"github.com/satori/go.uuid"
 	"net/http"
+
+	"github.com/satori/go.uuid"
 )
 
 type contextKey string

--- a/requestid/requestidmiddleware_test.go
+++ b/requestid/requestidmiddleware_test.go
@@ -2,10 +2,11 @@ package requestid_test
 
 import (
 	"fmt"
-	"github.com/d-velop/dvelop-sdk-go/requestid"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/d-velop/dvelop-sdk-go/requestid"
 )
 
 func TestShouldCallInnerHandler(t *testing.T) {

--- a/requestlog/requestlogmiddleware_test.go
+++ b/requestlog/requestlogmiddleware_test.go
@@ -3,12 +3,13 @@ package requestlog_test
 import (
 	"context"
 	"fmt"
-	"github.com/d-velop/dvelop-sdk-go/requestlog"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/d-velop/dvelop-sdk-go/requestlog"
 )
 
 func TestShouldCallInnerHandler(t *testing.T) {

--- a/tenant/tenantmiddleware_test.go
+++ b/tenant/tenantmiddleware_test.go
@@ -2,16 +2,15 @@ package tenant_test
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
 	"fmt"
-	"github.com/d-velop/dvelop-sdk-go/tenant"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"encoding/base64"
-
-	"crypto/hmac"
-	"crypto/sha256"
+	"github.com/d-velop/dvelop-sdk-go/tenant"
 )
 
 const systemBaseUriHeader = "x-dv-baseuri"


### PR DESCRIPTION
Format files with `goimports` to properly order the import statements.