### PR TITLE
Add a middleware to provide access to lambda aliases for feature toggles

### DIFF
--- a/idp/authmiddleware.go
+++ b/idp/authmiddleware.go
@@ -22,6 +22,7 @@ type contextKey string
 
 const principalKey = contextKey("Principal")
 const authSessionIdKey = contextKey("AuthSessionId")
+const userNameSuffixForApps = "@app.idp.d-velop.local"
 
 // HandleAuth authenticates the user using the IdentityProviderApp
 //
@@ -286,6 +287,11 @@ func PrincipalFromCtx(ctx context.Context) (scim.Principal, error) {
 		return scim.Principal{}, errors.New("no principal on context")
 	}
 	return principal, nil
+}
+
+func AppFromCtx( ctx context.Context) (string, bool) {
+	p, _ := PrincipalFromCtx(ctx)
+	return p.App()
 }
 
 func AuthSessionIdFromCtx(ctx context.Context) (string, error) {

--- a/idp/scim/user.go
+++ b/idp/scim/user.go
@@ -6,7 +6,6 @@ package scim
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 )
 

--- a/idp/scim/user.go
+++ b/idp/scim/user.go
@@ -6,6 +6,7 @@ package scim
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 )
 

--- a/idp/scim/user.go
+++ b/idp/scim/user.go
@@ -6,6 +6,11 @@ package scim
 
 import (
 	"encoding/json"
+	"strings"
+)
+
+const (
+	userNameSuffixForApps = "@app.idp.d-velop.local"
 )
 
 // Principal represents a user.
@@ -68,6 +73,14 @@ type Principal struct {
 func (p Principal) String() string {
 	b, _ := json.Marshal(p)
 	return string(b)
+}
+
+func (p Principal) App() (string, bool) {
+	if strings.HasSuffix(p.UserName, userNameSuffixForApps) {
+		return strings.TrimSuffix(p.UserName, userNameSuffixForApps), true
+	} else {
+		return "", false
+	}
 }
 
 type UserName struct {

--- a/lambdaenvironment/go.mod
+++ b/lambdaenvironment/go.mod
@@ -1,0 +1,8 @@
+module github.com/d-velop/dvelop-sdk-go/lambdaenvironment
+
+go 1.12
+
+require (
+	github.com/aws/aws-lambda-go v1.13.0
+	github.com/d-velop/dvelop-sdk-go/idp v0.0.0-20190816115847-198895963ddc
+)

--- a/lambdaenvironment/go.mod
+++ b/lambdaenvironment/go.mod
@@ -2,7 +2,4 @@ module github.com/d-velop/dvelop-sdk-go/lambdaenvironment
 
 go 1.12
 
-require (
-	github.com/aws/aws-lambda-go v1.13.0
-	github.com/d-velop/dvelop-sdk-go/idp v0.0.0-20190816115847-198895963ddc
-)
+require github.com/aws/aws-lambda-go v1.13.0

--- a/lambdaenvironment/go.sum
+++ b/lambdaenvironment/go.sum
@@ -1,11 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/aws/aws-lambda-go v1.13.0 h1:yjvZBGAxmrVQnakZ6/SE2S6L7Iwyx4CkJEcCQCc7WtU=
 github.com/aws/aws-lambda-go v1.13.0/go.mod h1:z4ywteZ5WwbIEzG0tXizIAUlUwkTNNknX4upd5Z5XJM=
-github.com/d-velop/dvelop-sdk-go/idp v0.0.0-20190816115847-198895963ddc h1:8shNTszZkyRrHaqJddcEBU3S4hvQ8UrqLjNXYFpLZ9I=
-github.com/d-velop/dvelop-sdk-go/idp v0.0.0-20190816115847-198895963ddc/go.mod h1:5QIi4aF/LsVOQ3vwcnKX9OdICQhdeaGlBmP5Bg+3ZyE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
-github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/lambdaenvironment/go.sum
+++ b/lambdaenvironment/go.sum
@@ -1,0 +1,14 @@
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/aws/aws-lambda-go v1.13.0 h1:yjvZBGAxmrVQnakZ6/SE2S6L7Iwyx4CkJEcCQCc7WtU=
+github.com/aws/aws-lambda-go v1.13.0/go.mod h1:z4ywteZ5WwbIEzG0tXizIAUlUwkTNNknX4upd5Z5XJM=
+github.com/d-velop/dvelop-sdk-go/idp v0.0.0-20190816115847-198895963ddc h1:8shNTszZkyRrHaqJddcEBU3S4hvQ8UrqLjNXYFpLZ9I=
+github.com/d-velop/dvelop-sdk-go/idp v0.0.0-20190816115847-198895963ddc/go.mod h1:5QIi4aF/LsVOQ3vwcnKX9OdICQhdeaGlBmP5Bg+3ZyE=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/urfave/cli v1.21.0/go.mod h1:lxDj6qX9Q6lWQxIrbrT0nwecwUtRnhVZAJjJZrVUZZQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/lambdaenvironment/lambdamiddleware.go
+++ b/lambdaenvironment/lambdamiddleware.go
@@ -1,0 +1,37 @@
+package lambdaenvironment
+
+import (
+	"context"
+	"github.com/aws/aws-lambda-go/lambdacontext"
+	"net/http"
+	"strings"
+)
+
+type contextKey string
+const environmentKey = contextKey("FeatureToggleEnvironment")
+
+func AddEnvironmentToCtx() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			ctx := req.Context()
+
+			if lc, success := lambdacontext.FromContext(ctx); success {
+				arn := lc.InvokedFunctionArn
+				arnParts := strings.Split(arn, ":")
+				if len(arnParts) == 8 {
+					ctx = context.WithValue(ctx, environmentKey, arnParts[7])
+				}
+			}
+
+			next.ServeHTTP(w, req.WithContext(ctx))
+		})
+	}
+}
+
+func EnvironmentFromCtx( ctx context.Context) string {
+	value, ok := ctx.Value(environmentKey).(string)
+	if !ok {
+		return ""
+	}
+	return value
+}

--- a/lambdaenvironment/lambdamiddleware.go
+++ b/lambdaenvironment/lambdamiddleware.go
@@ -8,27 +8,46 @@ import (
 )
 
 type contextKey string
+
 const environmentKey = contextKey("FeatureToggleEnvironment")
 
-func AddEnvironmentToCtx() func(http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			ctx := req.Context()
+// AddEnvironmentToCtx retrieves the current lambda alias/version and adds it to the context.
+//
+// You can use this to implement feature toggles that are dependent on the environment.
+//
+// Example:
+//  func main() {
+//    mux := http.NewServeMux()
+//    mux.Handle("/hello", lambdaenvironment.AddEnvironmentToCtx(someHandler()))
+//  }
+//
+//  func someHandler() http.Handler {
+//    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+//      environment := lambdaenvironment.EnvironmentFromCtx(r.Context())
+//      if environment == "dev" {
+//        fmt.Fprint(w, "Hey, here are some new features")
+//      } else {
+//        fmt.Fprint(w, "Hello, this is the production version")
+//      }
+//    })
+//  }
+func AddEnvironmentToCtx(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
 
-			if lc, success := lambdacontext.FromContext(ctx); success {
-				arn := lc.InvokedFunctionArn
-				arnParts := strings.Split(arn, ":")
-				if len(arnParts) == 8 {
-					ctx = context.WithValue(ctx, environmentKey, arnParts[7])
-				}
+		if lc, success := lambdacontext.FromContext(ctx); success {
+			arn := lc.InvokedFunctionArn
+			arnParts := strings.Split(arn, ":")
+			if len(arnParts) == 8 {
+				ctx = context.WithValue(ctx, environmentKey, arnParts[7])
 			}
+		}
 
-			next.ServeHTTP(w, req.WithContext(ctx))
-		})
-	}
+		next.ServeHTTP(w, req.WithContext(ctx))
+	})
 }
 
-func EnvironmentFromCtx( ctx context.Context) string {
+func EnvironmentFromCtx(ctx context.Context) string {
 	value, ok := ctx.Value(environmentKey).(string)
 	if !ok {
 		return ""

--- a/lambdaenvironment/lambdamiddleware_test.go
+++ b/lambdaenvironment/lambdamiddleware_test.go
@@ -20,7 +20,7 @@ func TestRequestToNamedAlias_ReturnsAliasFromArn(t *testing.T) {
 	})
 	handlerSpy := handlerSpy{}
 
-	lambdaenvironment.AddEnvironmentToCtx()(&handlerSpy).ServeHTTP(httptest.NewRecorder(), req.WithContext(ctx))
+	lambdaenvironment.AddEnvironmentToCtx(&handlerSpy).ServeHTTP(httptest.NewRecorder(), req.WithContext(ctx))
 
 	if !handlerSpy.hasBeenCalled {
 		t.Error("inner handler should have been called")
@@ -42,7 +42,7 @@ func TestRequestToVersionNumber_ReturnsVersionFromArn(t *testing.T) {
 	})
 	handlerSpy := handlerSpy{}
 
-	lambdaenvironment.AddEnvironmentToCtx()(&handlerSpy).ServeHTTP(httptest.NewRecorder(), req.WithContext(ctx))
+	lambdaenvironment.AddEnvironmentToCtx(&handlerSpy).ServeHTTP(httptest.NewRecorder(), req.WithContext(ctx))
 
 	if !handlerSpy.hasBeenCalled {
 		t.Error("inner handler should have been called")
@@ -64,7 +64,7 @@ func TestRequestToArnWithoutQualifier_ReturnsEmptyString(t *testing.T) {
 	})
 	handlerSpy := handlerSpy{}
 
-	lambdaenvironment.AddEnvironmentToCtx()(&handlerSpy).ServeHTTP(httptest.NewRecorder(), req.WithContext(ctx))
+	lambdaenvironment.AddEnvironmentToCtx(&handlerSpy).ServeHTTP(httptest.NewRecorder(), req.WithContext(ctx))
 
 	if !handlerSpy.hasBeenCalled {
 		t.Error("inner handler should have been called")
@@ -83,7 +83,7 @@ func TestRequestWithoutLambdaContext_ReturnsEmptyString(t *testing.T) {
 
 	handlerSpy := handlerSpy{}
 
-	lambdaenvironment.AddEnvironmentToCtx()(&handlerSpy).ServeHTTP(httptest.NewRecorder(), req)
+	lambdaenvironment.AddEnvironmentToCtx(&handlerSpy).ServeHTTP(httptest.NewRecorder(), req)
 
 	if !handlerSpy.hasBeenCalled {
 		t.Error("inner handler should have been called")

--- a/lambdaenvironment/lambdamiddleware_test.go
+++ b/lambdaenvironment/lambdamiddleware_test.go
@@ -1,0 +1,105 @@
+package lambdaenvironment_test
+
+import (
+	"context"
+	"github.com/aws/aws-lambda-go/lambdacontext"
+	"github.com/d-velop/dvelop-sdk-go/lambdaenvironment"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRequestToNamedAlias_ReturnsAliasFromArn(t *testing.T) {
+	req, err := http.NewRequest("GET", "/somewhere", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := lambdacontext.NewContext(context.Background(), &lambdacontext.LambdaContext{
+		InvokedFunctionArn: "arn:aws:lambda:eu-central-1:123456789012:function:some-function-name:some-version-tag",
+	})
+	handlerSpy := handlerSpy{}
+
+	lambdaenvironment.AddEnvironmentToCtx()(&handlerSpy).ServeHTTP(httptest.NewRecorder(), req.WithContext(ctx))
+
+	if !handlerSpy.hasBeenCalled {
+		t.Error("inner handler should have been called")
+	}
+
+	if handlerSpy.environment != "some-version-tag" {
+		t.Errorf("middleware returned wrong environment: got %v, want %v", handlerSpy.environment, "some-version-tag")
+	}
+}
+
+func TestRequestToVersionNumber_ReturnsVersionFromArn(t *testing.T) {
+	req, err := http.NewRequest("GET", "/somewhere", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := lambdacontext.NewContext(context.Background(), &lambdacontext.LambdaContext{
+		InvokedFunctionArn: "arn:aws:lambda:eu-central-1:123456789012:function:some-function-name:4711",
+	})
+	handlerSpy := handlerSpy{}
+
+	lambdaenvironment.AddEnvironmentToCtx()(&handlerSpy).ServeHTTP(httptest.NewRecorder(), req.WithContext(ctx))
+
+	if !handlerSpy.hasBeenCalled {
+		t.Error("inner handler should have been called")
+	}
+
+	if handlerSpy.environment != "4711" {
+		t.Errorf("middleware returned wrong environment: got %v, want %v", handlerSpy.environment, "4711")
+	}
+}
+
+func TestRequestToArnWithoutQualifier_ReturnsEmptyString(t *testing.T) {
+	req, err := http.NewRequest("GET", "/somewhere", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := lambdacontext.NewContext(context.Background(), &lambdacontext.LambdaContext{
+		InvokedFunctionArn: "arn:aws:lambda:eu-central-1:123456789012:function:some-function-name",
+	})
+	handlerSpy := handlerSpy{}
+
+	lambdaenvironment.AddEnvironmentToCtx()(&handlerSpy).ServeHTTP(httptest.NewRecorder(), req.WithContext(ctx))
+
+	if !handlerSpy.hasBeenCalled {
+		t.Error("inner handler should have been called")
+	}
+
+	if handlerSpy.environment != "" {
+		t.Errorf("middleware returned wrong environment: got %v, want %v", handlerSpy.environment, "")
+	}
+}
+
+func TestRequestWithoutLambdaContext_ReturnsEmptyString(t *testing.T) {
+	req, err := http.NewRequest("GET", "/somewhere", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handlerSpy := handlerSpy{}
+
+	lambdaenvironment.AddEnvironmentToCtx()(&handlerSpy).ServeHTTP(httptest.NewRecorder(), req)
+
+	if !handlerSpy.hasBeenCalled {
+		t.Error("inner handler should have been called")
+	}
+
+	if handlerSpy.environment != "" {
+		t.Errorf("middleware returned wrong environment: got %v, want %v", handlerSpy.environment, "")
+	}
+}
+
+type handlerSpy struct {
+	hasBeenCalled bool
+	environment   string
+}
+
+func (spy *handlerSpy) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	spy.hasBeenCalled = true
+	spy.environment = lambdaenvironment.EnvironmentFromCtx(r.Context())
+}


### PR DESCRIPTION
Using this middleware, you can implement feature toggles based on the current lambda alias.
Example:
```example.go
func main() {
  mux := http.NewServeMux()
  mux.Handle("/hello", lambdaenvironment.AddEnvironmentToCtx(someHandler()))
}

func someHandler() http.Handler {
  return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
    environment := lambdaenvironment.EnvironmentFromCtx(r.Context())
    if environment == "dev" {
      fmt.Fprint(w, "Hey, here are some new features")
    } else {
      fmt.Fprint(w, "Hello, this is the production version")
    }
  })
}
```