### PR TITLE
Add support for using "app sessions" with the d.ecs identityprovider

### DIFF
--- a/idp/authmiddleware.go
+++ b/idp/authmiddleware.go
@@ -296,7 +296,7 @@ func AuthSessionIdFromCtx(ctx context.Context) (string, error) {
 	return authSessionId, nil
 }
 
-func AppFromCtx(ctx context.Context) (string, bool) {
+func AppFromCtx(ctx context.Context) (appName string, isApp bool) {
 	if principal, err := PrincipalFromCtx(ctx); err == nil {
 		return principal.App()
 	} else {

--- a/idp/authmiddleware.go
+++ b/idp/authmiddleware.go
@@ -295,3 +295,11 @@ func AuthSessionIdFromCtx(ctx context.Context) (string, error) {
 	}
 	return authSessionId, nil
 }
+
+func AppFromCtx(ctx context.Context) (string, bool) {
+	if principal, err := PrincipalFromCtx(ctx); err == nil {
+		return principal.App()
+	} else {
+		return "", false
+	}
+}

--- a/idp/scim/user.go
+++ b/idp/scim/user.go
@@ -73,7 +73,7 @@ func (p Principal) String() string {
 	return string(b)
 }
 
-func (p Principal) App() (string, bool) {
+func (p Principal) App() (appName string, isApp bool) {
 	if strings.HasSuffix(p.Id, appSessionIdSuffix) {
 		return strings.TrimSuffix(p.Id, appSessionIdSuffix), true
 	}

--- a/idp/scim/user.go
+++ b/idp/scim/user.go
@@ -6,7 +6,10 @@ package scim
 
 import (
 	"encoding/json"
+	"strings"
 )
+
+const appSessionIdSuffix  = "@app.idp.d-velop.local"
 
 // Principal represents a user.
 //
@@ -68,6 +71,13 @@ type Principal struct {
 func (p Principal) String() string {
 	b, _ := json.Marshal(p)
 	return string(b)
+}
+
+func (p Principal) App() (string, bool) {
+	if strings.HasSuffix(p.Id, appSessionIdSuffix) {
+		return strings.TrimSuffix(p.Id, appSessionIdSuffix), true
+	}
+	return "", false
 }
 
 type UserName struct {

--- a/idp/scim/user_test.go
+++ b/idp/scim/user_test.go
@@ -22,3 +22,16 @@ func TestCanDeserializeSCIMUser(t *testing.T) {
 		t.Errorf("Unmarshaled Object wrong: got \n %v want\n %v", u, donaldDuck)
 	}
 }
+
+func TestUserHasAppId_ReturnsApp( t *testing.T) {
+	principal := scim.Principal{Id: "some-app@app.idp.d-velop.local"}
+	app, isApp := principal.App()
+
+	if !isApp {
+		t.Errorf("expected isApp = true, got false")
+	}
+
+	if app != "some-app" {
+		t.Errorf("expected app = 'some-app', got %v", app)
+	}
+}

--- a/idp/scim/user_test.go
+++ b/idp/scim/user_test.go
@@ -35,3 +35,15 @@ func TestUserHasAppId_ReturnsApp( t *testing.T) {
 		t.Errorf("expected app = 'some-app', got %v", app)
 	}
 }
+
+func TestUserHasNonAppId_ReturnsNoApp( t *testing.T) {
+	appName, isApp := donaldDuck.App()
+
+	if isApp {
+		t.Errorf("expected isApp = false")
+	}
+
+	if appName != "" {
+		t.Errorf("expected appName = '', got appNAme = '%v'", appName)
+	}
+}


### PR DESCRIPTION
This pull request implements support to use "app sessions" with the d.ecs identityprovider.

To use this in you app, you can either retrieve a full scim.Principal and as the sdk if its an app principal. This might be useful if your ressource can be called from both apps and real users.
```example1.go
principal = idp.PrincipalFromCtx(request.Context())
appName, isApp := principal.App()

if isApp {
	log.Infof(request.Context(), "Hello app %v", appName)
} else {
	log.Infof(request.Context(), "Hello user %v", principal.UserName)
}
```

Or, if your ressource is only ever to be used using an app principal, ask explicitly for that.
```example2.go
appName, isApp := idp.AppFromCtx(context.Background())

if isApp {
	log.Infof(request.Context(), "Hello App %v", appName)
} else {
	panic("illegal session") // bad idea
}
```