### PR TITLE
fixed double decoding of Queryparameters

### DIFF
--- a/lambda/server.go
+++ b/lambda/server.go
@@ -28,7 +28,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"sort"
 	"strings"
 
 	"github.com/aws/aws-lambda-go/events"
@@ -126,24 +125,11 @@ func mapMethod(e *events.APIGatewayProxyRequest) string {
 func mapURL(e *events.APIGatewayProxyRequest) *url.URL {
 	u := &url.URL{Path: e.Path}
 	if e.QueryStringParameters != nil {
-		qspKeys := make([]string, 0, len(e.QueryStringParameters))
-		for k := range e.QueryStringParameters {
-			qspKeys = append(qspKeys, k)
+		values := make(url.Values)
+		for key, value := range e.QueryStringParameters {
+			values.Add(key, value)
 		}
-		sort.Strings(qspKeys)
-
-		var buf bytes.Buffer
-		var l = len(e.QueryStringParameters)
-
-		for i, k := range qspKeys {
-			buf.WriteString(k)
-			buf.WriteString("=")
-			buf.WriteString(e.QueryStringParameters[k])
-			if i < l-1 {
-				buf.WriteString("&")
-			}
-		}
-		u.RawQuery = buf.String()
+		u.RawQuery = values.Encode()
 	}
 	return u
 }

--- a/lambda/server_test.go
+++ b/lambda/server_test.go
@@ -76,6 +76,7 @@ func TestAdaptor_InvokesHandlerWithCorrectURL(t *testing.T) {
 	// sort query parameter by key
 	invokeAdaptorFunc(t, &events.APIGatewayProxyRequest{Path: "/path", QueryStringParameters: map[string]string{"bar": "2", "foo": "1"}}).invokesHandlerWithURL(&url.URL{Path: "/path", RawQuery: "bar=2&foo=1"})
 	invokeAdaptorFunc(t, &events.APIGatewayProxyRequest{Path: "/path", QueryStringParameters: map[string]string{"foo": "1", "bar": "2"}}).invokesHandlerWithURL(&url.URL{Path: "/path", RawQuery: "bar=2&foo=1"})
+	invokeAdaptorFunc(t, &events.APIGatewayProxyRequest{Path: "/path", QueryStringParameters: map[string]string{"foo": "foo+bar@test.de", "bar": "2"}}).invokesHandlerWithURL(&url.URL{Path: "/path", RawQuery: "bar=2&foo=foo%2Bbar%40test.de"})
 }
 
 func (tr *testresult) invokesHandlerWithURL(expected *url.URL) {


### PR DESCRIPTION
Fixes #20 

The mapURL function now encodes the RawQuery, so you can use http.Request.URL.Query().Get to get the correct decoded value of a query parameter.

I also added a test with some special characters.
