### PR TITLE
response of headers changed to support multi value headers

### DIFF
--- a/lambda/go.mod
+++ b/lambda/go.mod
@@ -1,5 +1,5 @@
 module github.com/d-velop/dvelop-sdk-go/lambda
 
-require github.com/aws/aws-lambda-go v1.8.0
+require github.com/aws/aws-lambda-go v1.17.0
 
 go 1.13

--- a/lambda/go.sum
+++ b/lambda/go.sum
@@ -1,2 +1,15 @@
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/aws/aws-lambda-go v1.8.0 h1:YMCzi9FP7MNVVj9AkGpYyaqh/mvFOjhqiDtnNlWtKTg=
 github.com/aws/aws-lambda-go v1.8.0/go.mod h1:zUsUQhAUjYzR8AuduJPCfhBuKWUaDbQiPOG+ouzmE1A=
+github.com/aws/aws-lambda-go v1.17.0 h1:Ogihmi8BnpmCNktKAGpNwSiILNNING1MiosnKUfU8m0=
+github.com/aws/aws-lambda-go v1.17.0/go.mod h1:FEwgPLE6+8wcGBTe5cJN3JWurd1Ztm9zN4jsXsjzKKw=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/urfave/cli/v2 v2.1.1/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/lambda/server.go
+++ b/lambda/server.go
@@ -156,10 +156,7 @@ func (rw *responseWriter) response() (*events.APIGatewayProxyResponse, error) {
 	response := &events.APIGatewayProxyResponse{}
 
 	if rw.snapHeader != nil && len(rw.snapHeader) > 0 {
-		response.Headers = map[string]string{}
-		for key, value := range rw.snapHeader {
-			response.Headers[key] = strings.Join(value, ", ")
-		}
+		response.MultiValueHeaders = rw.snapHeader
 	}
 
 	if rw.body.Len() > 0 {

--- a/lambda/server_test.go
+++ b/lambda/server_test.go
@@ -234,8 +234,8 @@ func TestAdaptor_HandlerSetsHeaderAndCallsWriteHeader_ReturnsHeaderAndStatusCode
 	handler := lambda.AdaptorFunc(spy, nullLog, nullLog)
 	resp, _ := handler(context.Background(), events.APIGatewayProxyRequest{})
 
-	expected := map[string]string{"X-Error": "502"}
-	if !reflect.DeepEqual(resp.Headers, expected) {
+	expected := map[string][]string{"X-Error": {"502"}}
+	if !reflect.DeepEqual(resp.MultiValueHeaders, expected) {
 		t.Errorf("Serve: should return headers '%v' set by handler but returned headers '%v' ", expected, resp.Headers)
 	}
 	if resp.StatusCode != http.StatusInternalServerError {
@@ -253,8 +253,8 @@ func TestAdaptor_HandlerSetsHeaderWithMultipleValues_ReturnsHeaderWithMultipleVa
 	handler := lambda.AdaptorFunc(spy, nullLog, nullLog)
 	resp, _ := handler(context.Background(), events.APIGatewayProxyRequest{})
 
-	expected := map[string]string{"Content-Type": "application/json, text/html"}
-	if !reflect.DeepEqual(resp.Headers, expected) {
+	expected := map[string][]string{"Content-Type": {"application/json", "text/html"}}
+	if !reflect.DeepEqual(resp.MultiValueHeaders, expected) {
 		t.Errorf("Serve: should return headers '%v' set by handler but returned headers '%v' ", expected, resp.Headers)
 	}
 	if resp.StatusCode != http.StatusInternalServerError {
@@ -272,8 +272,8 @@ func TestAdaptor_HandlerModifiesHeaderAfterCallingWriteHeader_ReturnsUnmodifiedH
 	handler := lambda.AdaptorFunc(spy, nullLog, nullLog)
 	resp, _ := handler(context.Background(), events.APIGatewayProxyRequest{})
 
-	expected := map[string]string{"X-Header": "value"}
-	if !reflect.DeepEqual(expected, resp.Headers) {
+	expected := map[string][]string{"X-Header": {"value"}}
+	if !reflect.DeepEqual(expected, resp.MultiValueHeaders) {
 		t.Errorf("Serve: should return headers '%v' set by handler but returned headers '%v' ", expected, resp.Headers)
 	}
 }
@@ -287,8 +287,8 @@ func TestAdaptor_HandlerDoesntSetContentTypeAndCallsWrite_ReturnsDetectedContent
 	handler := lambda.AdaptorFunc(spy, nullLog, nullLog)
 	resp, _ := handler(context.Background(), events.APIGatewayProxyRequest{})
 
-	expected := map[string]string{"Content-Type": "text/html; charset=utf-8"}
-	if !reflect.DeepEqual(resp.Headers, expected) {
+	expected := map[string][]string{"Content-Type": {"text/html; charset=utf-8"}}
+	if !reflect.DeepEqual(resp.MultiValueHeaders, expected) {
 		t.Errorf("Serve: should return headers '%v' set by handler but returned headers '%v' ", expected, resp.Headers)
 	}
 	if !reflect.DeepEqual(resp.Body, body) {
@@ -308,8 +308,8 @@ func TestAdaptor_HandlerSetsContentTypeAndCallsWrite_ReturnsContentTypeHeaderAnd
 	handler := lambda.AdaptorFunc(spy, nullLog, nullLog)
 	resp, _ := handler(context.Background(), events.APIGatewayProxyRequest{})
 
-	expected := map[string]string{"Content-Type": "application/vnd+company.category+json"}
-	if !reflect.DeepEqual(resp.Headers, expected) {
+	expected := map[string][]string{"Content-Type": {"application/vnd+company.category+json"}}
+	if !reflect.DeepEqual(resp.MultiValueHeaders, expected) {
 		t.Errorf("Serve: should return headers '%v' set by handler but returned headers '%v' ", expected, resp.Headers)
 	}
 	if !reflect.DeepEqual(resp.Body, `{"Key": "value"}`) {
@@ -330,8 +330,8 @@ func TestAdaptor_HandlerSetsContentTypeAndCallsWriteHeaderAndCallsWrite_ReturnsC
 	handler := lambda.AdaptorFunc(spy, nullLog, nullLog)
 	resp, _ := handler(context.Background(), events.APIGatewayProxyRequest{})
 
-	expected := map[string]string{"X-Header": "value"}
-	if !reflect.DeepEqual(resp.Headers, expected) {
+	expected := map[string][]string{"X-Header": {"value"}}
+	if !reflect.DeepEqual(resp.MultiValueHeaders, expected) {
 		t.Errorf("Serve: should return headers '%v' set by handler but returned headers '%v' ", expected, resp.Headers)
 	}
 	if !reflect.DeepEqual(resp.Body, "type not acceptable") {
@@ -353,7 +353,7 @@ func TestAdaptor_HandlerModifiesHeaderAfterWriteAndCallsWriteHeader_ReturnsUnmod
 	handler := lambda.AdaptorFunc(spy, nullLog, nullLog)
 	resp, _ := handler(context.Background(), events.APIGatewayProxyRequest{})
 
-	if resp.Headers["X-Header"] != "value" {
+	if resp.MultiValueHeaders["X-Header"][0] != "value" {
 		t.Errorf("Serve: should return unmodified header value '%v' but returned modified header value '%v'", "value", resp.Headers["X-Header"])
 	}
 }


### PR DESCRIPTION
fix for #24 

see https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format for information on how the response is handled by api gateway