### PR TITLE
added support for initiatorSystemBaseUri for Hybridsystems

### DIFF
--- a/tenant/tenantmiddleware.go
+++ b/tenant/tenantmiddleware.go
@@ -152,7 +152,6 @@ func getForwardedHeaderFirstHostValueAsUri(headerValue string) string {
 			if strings.HasPrefix(value, forwardedHostPattern) {
 				hostValue := strings.TrimPrefix(value, forwardedHostPattern)
 				host := getFirstValueOfDelimitedList(hostValue, commaDelimiter)
-				log.Printf("value before trim %s after trim %s and the result host %s", value, hostValue, host)
 				if host != "" {
 					return uriPrefix + host
 				}

--- a/tenant/tenantmiddleware_test.go
+++ b/tenant/tenantmiddleware_test.go
@@ -13,10 +13,15 @@ import (
 	"github.com/d-velop/dvelop-sdk-go/tenant"
 )
 
-const systemBaseUriHeader = "x-dv-baseuri"
-const tenantIdHeader = "x-dv-tenant-id"
-const signatureHeader = "x-dv-sig-1"
-const defaultSystemBaseUri = "https://default.example.com"
+const (
+	systemBaseUriHeader  = "x-dv-baseuri"
+	tenantIdHeader       = "x-dv-tenant-id"
+	signatureHeader      = "x-dv-sig-1"
+	defaultSystemBaseUri = "https://default.example.com"
+	forwardedHeader      = "forwarded"
+	xForwardedHostHeader = "x-forwarded-host"
+	uriPrefix            = "https://"
+)
 
 func TestBaseUriHeaderAndEmptyDefaultBaseUri_UsesHeader(t *testing.T) {
 	req, err := http.NewRequest("GET", "/myresource/sub", nil)
@@ -131,6 +136,154 @@ func TestNoTenantIdHeader_UsesTenantIdZero(t *testing.T) {
 	}
 }
 
+func TestInitiatorSystemBaseUriHeader_UsesForwardedHeader(t *testing.T) {
+	req, err := http.NewRequest("GET", "/myresource/sub", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const forwardedHostValue = "forwarded.example.com"
+	const forwardedHeaderValue = "host=" + forwardedHostValue
+	req.Header.Set(forwardedHeader, forwardedHeaderValue)
+	req.Header.Set(signatureHeader, base64Signature(forwardedHeaderValue, signatureKey))
+	handlerSpy := handlerSpy{}
+	responseSpy := responseSpy{httptest.NewRecorder()}
+
+	tenant.AddToCtx("", signatureKey)(&handlerSpy).ServeHTTP(responseSpy, req)
+
+	if err := responseSpy.assertStatusCodeIs(http.StatusOK); err != nil {
+		t.Error(err)
+	}
+	if err := handlerSpy.assertInitiatorSystemBaseUriIs(uriPrefix + forwardedHostValue); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestInitiatorSystemBaseUriHeader_UsesForwardedHeaderMultipleHosts(t *testing.T) {
+	req, err := http.NewRequest("GET", "/myresource/sub", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const forwardedHostValue = "forwarded.example.com"
+	const forwardedHeaderValue = "host=" + forwardedHostValue + ",secondhost.example.com"
+	req.Header.Set(forwardedHeader, forwardedHeaderValue)
+	req.Header.Set(signatureHeader, base64Signature(forwardedHeaderValue, signatureKey))
+	handlerSpy := handlerSpy{}
+	responseSpy := responseSpy{httptest.NewRecorder()}
+
+	tenant.AddToCtx("", signatureKey)(&handlerSpy).ServeHTTP(responseSpy, req)
+
+	if err := responseSpy.assertStatusCodeIs(http.StatusOK); err != nil {
+		t.Error(err)
+	}
+	if err := handlerSpy.assertInitiatorSystemBaseUriIs(uriPrefix + forwardedHostValue); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestInitiatorSystemBaseUriHeader_UsesXForwardedHeader(t *testing.T) {
+	req, err := http.NewRequest("GET", "/myresource/sub", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const xForwardedHostValue = "xforwarded.example.com"
+	req.Header.Set(xForwardedHostHeader, xForwardedHostValue)
+	req.Header.Set(signatureHeader, base64Signature(xForwardedHostValue, signatureKey))
+	handlerSpy := handlerSpy{}
+	responseSpy := responseSpy{httptest.NewRecorder()}
+
+	tenant.AddToCtx("", signatureKey)(&handlerSpy).ServeHTTP(responseSpy, req)
+
+	if err := responseSpy.assertStatusCodeIs(http.StatusOK); err != nil {
+		t.Error(err)
+	}
+	if err := handlerSpy.assertInitiatorSystemBaseUriIs(uriPrefix + xForwardedHostValue); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestInitiatorSystemBaseUriHeader_UsesXForwardedHeaderMultipleHosts(t *testing.T) {
+	req, err := http.NewRequest("GET", "/myresource/sub", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const xForwardedHostValue = "xforwarded.example.com"
+	const xForwardedHostMultiValue = xForwardedHostValue + ",secondhost.example.com"
+	req.Header.Set(xForwardedHostHeader, xForwardedHostMultiValue)
+	req.Header.Set(signatureHeader, base64Signature(xForwardedHostMultiValue, signatureKey))
+	handlerSpy := handlerSpy{}
+	responseSpy := responseSpy{httptest.NewRecorder()}
+
+	tenant.AddToCtx("", signatureKey)(&handlerSpy).ServeHTTP(responseSpy, req)
+
+	if err := responseSpy.assertStatusCodeIs(http.StatusOK); err != nil {
+		t.Error(err)
+	}
+	if err := handlerSpy.assertInitiatorSystemBaseUriIs(uriPrefix + xForwardedHostValue); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestInitiatorSystemBaseUriHeader_EmptyForwardedHeadersNoSystemBaseUri(t *testing.T) {
+	req, err := http.NewRequest("GET", "/myresource/sub", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header.Set(signatureHeader, base64Signature("", signatureKey))
+	handlerSpy := handlerSpy{}
+	responseSpy := responseSpy{httptest.NewRecorder()}
+
+	tenant.AddToCtx("", signatureKey)(&handlerSpy).ServeHTTP(responseSpy, req)
+
+	if err := responseSpy.assertStatusCodeIs(http.StatusOK); err != nil {
+		t.Error(err)
+	}
+	if err := handlerSpy.assertInitiatorSystemBaseUriIs(""); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestInitiatorSystemBaseUriHeader_EmptyForwardedHeadersWithSystemBaseUri(t *testing.T) {
+	req, err := http.NewRequest("GET", "/myresource/sub", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const systemBaseUri = "https://sample.example.com"
+	req.Header.Set(systemBaseUriHeader, systemBaseUri)
+	req.Header.Set(signatureHeader, base64Signature(systemBaseUri, signatureKey))
+	handlerSpy := handlerSpy{}
+	responseSpy := responseSpy{httptest.NewRecorder()}
+
+	tenant.AddToCtx("", signatureKey)(&handlerSpy).ServeHTTP(responseSpy, req)
+
+	if err := responseSpy.assertStatusCodeIs(http.StatusOK); err != nil {
+		t.Error(err)
+	}
+	if err := handlerSpy.assertInitiatorSystemBaseUriIs(systemBaseUri); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestInitiatorSystemBaseUriHeader_EmptyForwardedHeadersWithDefaultSystemBaseUri(t *testing.T) {
+	req, err := http.NewRequest("GET", "/myresource/sub", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const defaultSystemBaseUri = "https://sample.example.com"
+
+	handlerSpy := handlerSpy{}
+	responseSpy := responseSpy{httptest.NewRecorder()}
+
+	tenant.AddToCtx(defaultSystemBaseUri, signatureKey)(&handlerSpy).ServeHTTP(responseSpy, req)
+
+	if err := responseSpy.assertStatusCodeIs(http.StatusOK); err != nil {
+		t.Error(err)
+	}
+	if err := handlerSpy.assertInitiatorSystemBaseUriIs(defaultSystemBaseUri); err != nil {
+		t.Error(err)
+	}
+}
+
 func TestTenantIdHeaderAndBaseUriHeader_UsesHeaders(t *testing.T) {
 	req, err := http.NewRequest("GET", "/myresource/sub", nil)
 	if err != nil {
@@ -153,6 +306,9 @@ func TestTenantIdHeaderAndBaseUriHeader_UsesHeaders(t *testing.T) {
 		t.Error(err)
 	}
 	if err := handlerSpy.assertBaseUriIs(systemBaseUriFromHeader); err != nil {
+		t.Error(err)
+	}
+	if err := handlerSpy.assertInitiatorSystemBaseUriIs(systemBaseUriFromHeader); err != nil {
 		t.Error(err)
 	}
 }
@@ -179,6 +335,9 @@ func TestTenantIdHeaderAndNoBaseUriHeader_UsesTenantIdHeaderAndDefaultSystemBase
 	if err := handlerSpy.assertBaseUriIs(defaultSystemBaseUri); err != nil {
 		t.Error(err)
 	}
+	if err := handlerSpy.assertInitiatorSystemBaseUriIs(defaultSystemBaseUri); err != nil {
+		t.Error(err)
+	}
 }
 
 func TestNoHeadersButDefaultSystemBaseUri_UsesDefaultBaseUriAndTenantIdZero(t *testing.T) {
@@ -200,6 +359,9 @@ func TestNoHeadersButDefaultSystemBaseUri_UsesDefaultBaseUriAndTenantIdZero(t *t
 	if err := handlerSpy.assertBaseUriIs(defaultSystemBaseUri); err != nil {
 		t.Error(err)
 	}
+	if err := handlerSpy.assertInitiatorSystemBaseUriIs(defaultSystemBaseUri); err != nil {
+		t.Error(err)
+	}
 }
 
 func TestNoHeadersButDefaultSystemBaseUriAndNoSignatureSecretKey_UsesDefaultBaseUriAndTenantIdZero(t *testing.T) {
@@ -219,6 +381,9 @@ func TestNoHeadersButDefaultSystemBaseUriAndNoSignatureSecretKey_UsesDefaultBase
 		t.Error(err)
 	}
 	if err := handlerSpy.assertBaseUriIs(defaultSystemBaseUri); err != nil {
+		t.Error(err)
+	}
+	if err := handlerSpy.assertInitiatorSystemBaseUriIs(defaultSystemBaseUri); err != nil {
 		t.Error(err)
 	}
 }
@@ -368,6 +533,21 @@ func TestSystemBaseUriOnContext_SetSystemBaseUri_ReturnsContextWithNewSystemBase
 	}
 }
 
+func TestInitiatorSystemBaseUriOnContext_SetInitiatorSystemBaseUri_ReturnsContextWithInitiatorSystemBaseUri(t *testing.T) {
+	ctx := tenant.SetInitiatorSystemBaseUri(context.Background(), "https://initial.example.com")
+	if u, _ := tenant.InitiatorSystemBaseUriFromCtx(ctx); u != "https://initial.example.com" {
+		t.Errorf("got wrong initiatorSystemBaseUri from context: got %v want %v", u, "https://initial.example.com")
+	}
+}
+
+func TestInitiatorSystemBaseUriOnContext_SetInitiatorSystemBaseUri_ReturnsContextWithNewInitiatorSystemBaseUri(t *testing.T) {
+	ctx := tenant.SetInitiatorSystemBaseUri(context.Background(), "https://initial.example.com")
+	ctx = tenant.SetInitiatorSystemBaseUri(context.Background(), "https://new.example.com")
+	if u, _ := tenant.InitiatorSystemBaseUriFromCtx(ctx); u != "https://new.example.com" {
+		t.Errorf("got wrong initiatorSystemBaseUri from context: got %v want %v", u, "https://new.example.com")
+	}
+}
+
 var signatureKey = []byte{166, 219, 144, 209, 189, 1, 178, 73, 139, 47, 21, 236, 142, 56, 71, 245, 43, 188, 163, 52, 239, 102, 94, 153, 255, 159, 199, 149, 163, 145, 161, 24}
 
 func base64Signature(message string, sigKey []byte) string {
@@ -377,17 +557,20 @@ func base64Signature(message string, sigKey []byte) string {
 }
 
 type handlerSpy struct {
-	systemBaseUri             string
-	tenantId                  string
-	errorReadingSystemBaseUri error
-	errorReadingTenantId      error
-	hasBeenCalled             bool
+	systemBaseUri                      string
+	tenantId                           string
+	initiatorSystemBaseUri             string
+	errorReadingSystemBaseUri          error
+	errorReadingTenantId               error
+	errorReadingInitiatorSystemBaseUri error
+	hasBeenCalled                      bool
 }
 
 func (spy *handlerSpy) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	spy.hasBeenCalled = true
 	spy.systemBaseUri, spy.errorReadingSystemBaseUri = tenant.SystemBaseUriFromCtx(r.Context())
 	spy.tenantId, spy.errorReadingTenantId = tenant.IdFromCtx(r.Context())
+	spy.initiatorSystemBaseUri, spy.errorReadingInitiatorSystemBaseUri = tenant.InitiatorSystemBaseUriFromCtx(r.Context())
 }
 
 func (spy *handlerSpy) assertBaseUriIs(expected string) error {
@@ -404,6 +587,13 @@ func (spy *handlerSpy) assertTenantIdIs(expected string) error {
 	return nil
 }
 
+func (spy *handlerSpy) assertInitiatorSystemBaseUriIs(expected string) error {
+	if spy.initiatorSystemBaseUri != expected {
+		return fmt.Errorf("handler set wrong initiatorSystemBaseUri on context: got %v want %v", spy.initiatorSystemBaseUri, expected)
+	}
+	return nil
+}
+
 func (spy *handlerSpy) assertErrorReadingSystemBaseUri() error {
 	if spy.errorReadingSystemBaseUri == nil {
 		return fmt.Errorf("expected error while reading systemBaseUri from context")
@@ -414,6 +604,13 @@ func (spy *handlerSpy) assertErrorReadingSystemBaseUri() error {
 func (spy *handlerSpy) assertErrorReadingTenantId() error {
 	if spy.errorReadingTenantId == nil {
 		return fmt.Errorf("expected error while reading tenantId from context")
+	}
+	return nil
+}
+
+func (spy *handlerSpy) assertErrorReadingInitiatorSystemBaseUri() error {
+	if spy.errorReadingTenantId == nil {
+		return fmt.Errorf("expected error while reading initiatorSystembaseUri from context")
 	}
 	return nil
 }


### PR DESCRIPTION
In hybrid system (onprem d.3 one and using d.velop cloud apps) it is sometimes neccessary to know the hostname or respectively the uri of the initiating server (f.e. to gernerate absolute callbackurls).  I added in AddToCtx the functionality to deteremine the uri of the initiating host. 
The uri of the system can be get via InitiatorSystemBaseUriFromCtx analog to the existing function for tenantId and SystemBaseUri.