### PR TITLE
handle idp user not found with return code nil, instead of returning an error

### DIFF
--- a/idp/idpclient/client.go
+++ b/idp/idpclient/client.go
@@ -189,6 +189,7 @@ func (c *client) GetPrincipalById(ctx context.Context, systemBaseUri string, ten
 		return nil, fmt.Errorf("user is not allowed to invoke '%s'. Identityprovider returned HTTP-Statuscode '%d' and message '%s'",
 			resp.Request.URL, resp.StatusCode, responseMsg)
 	case http.StatusNotFound:
+		_, _ = ioutil.ReadAll(resp.Body)
 		return nil, nil
 	default:
 		responseMsg, _ := ioutil.ReadAll(resp.Body)

--- a/idp/idpclient/client.go
+++ b/idp/idpclient/client.go
@@ -163,6 +163,10 @@ func (c *client) Validate(ctx context.Context, systemBaseUri string, tenantId st
 /*
 GetPrincipalById gets the principal specified by principalId for the tenant specified by systemBaseUri and tenantId.
 The authSessionId is used to authorize the request.
+
+If the user exists, a none nil *scim.Principal is returned.
+Otherwise the returned *scim.Principal is nil.
+
 */
 func (c *client) GetPrincipalById(ctx context.Context, systemBaseUri string, tenantId string, authSessionId string, principalId string) (*scim.Principal, error) {
 	// tenantid not used so far but included to implement a cache without changing the method signature
@@ -185,9 +189,7 @@ func (c *client) GetPrincipalById(ctx context.Context, systemBaseUri string, ten
 		return nil, fmt.Errorf("user is not allowed to invoke '%s'. Identityprovider returned HTTP-Statuscode '%d' and message '%s'",
 			resp.Request.URL, resp.StatusCode, responseMsg)
 	case http.StatusNotFound:
-		responseMsg, _ := ioutil.ReadAll(resp.Body)
-		return nil, fmt.Errorf("user '%s' doesn't exist. Identityprovider returned HTTP-Statuscode '%d' and message '%s'",
-			resp.Request.URL, resp.StatusCode, responseMsg)
+		return nil, nil
 	default:
 		responseMsg, _ := ioutil.ReadAll(resp.Body)
 		return nil, fmt.Errorf("unexpected error. Identityprovider '%s' returned HTTP-Statuscode '%d' and message '%s'",

--- a/idp/idpclient/client_test.go
+++ b/idp/idpclient/client_test.go
@@ -397,7 +397,7 @@ func TestCallerIsAuthorizedAndPrincipalExists_GetPrincipalById_ReturnsPrincipal(
 	}
 }
 
-func TestCallerIsAuthorizedAndPrincipalDoesntExist_GetPrincipalById_ReturnsError(t *testing.T) {
+func TestCallerIsAuthorizedAndPrincipalDoesntExist_GetPrincipalById_ReturnsNil(t *testing.T) {
 	const authSessionIdFromAuthorizedCaller = validAuthSessionId
 	existingPrincipal := scim.Principal{Id: "719052ec-0c46-4db4-9cc4-f57e6492d25d"}
 	idpStub := test.NewIdpUsersStub(authSessionIdFromAuthorizedCaller, existingPrincipal)
@@ -405,8 +405,12 @@ func TestCallerIsAuthorizedAndPrincipalDoesntExist_GetPrincipalById_ReturnsError
 	noneExistingPrincipalId := "83db85b2-89d3-4586-b455-ad041ff38195"
 	got, err := defaultClient.GetPrincipalById(context.Background(), idpStub.URL, "1", authSessionIdFromAuthorizedCaller, noneExistingPrincipalId)
 
-	if err == nil || got != nil {
-		t.Errorf("expected an error because principal with id '%s' doesn't exist but got no error", noneExistingPrincipalId)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if got != nil {
+		t.Errorf("expected principal value nil, got %v ",got)
 	}
 }
 


### PR DESCRIPTION
The idp http return code 404 should not be an error. 

It should be handled by returning a nil *scim.Principal value 

@mtestrot 