### PR TITLE
Change function definition of Info(), Debug() and Error()

### DIFF
--- a/otellog/log.go
+++ b/otellog/log.go
@@ -22,7 +22,7 @@ type Time func() time.Time
 
 type Hook func(ctx context.Context, e *Event)
 
-type OutputFormatter func(e *Event, msg string) ([]byte, error)
+type OutputFormatter func(e *Event) ([]byte, error)
 
 // New creates a new Logger.
 func New() *Logger {
@@ -45,13 +45,13 @@ func (l *Logger) Reset() {
 	l.hooks = nil
 	l.out = os.Stdout
 	l.time = time.Now
-	l.outputFormatter = func(e *Event, msg string) ([]byte, error) {
+	l.outputFormatter = func(e *Event) ([]byte, error) {
 		return json.Marshal(e)
 	}
 }
 
 // output writes the output for a logging event.
-func (l *Logger) output(ctx context.Context, sev Severity, msg string, options []Option) {
+func (l *Logger) output(ctx context.Context, sev Severity, msg interface{}, options []Option) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
@@ -70,7 +70,7 @@ func (l *Logger) output(ctx context.Context, sev Severity, msg string, options [
 		o(&e)
 	}
 
-	s, err := l.outputFormatter(&e, msg)
+	s, err := l.outputFormatter(&e)
 	if err == nil {
 		if len(s) == 0 || s[len(s)-1] != '\n' {
 			s = append(s, '\n')
@@ -108,9 +108,9 @@ func RegisterHook(h Hook) {
 	std.hooks = append(std.hooks, h)
 }
 
-// Debug is equivalent to log.StdDebug.Print()
-func Debug(ctx context.Context, v ...interface{}) {
-	std.output(ctx, SeverityDebug, fmt.Sprint(v...), nil)
+// Debug logs an event body according to the otel definition
+func Debug(ctx context.Context, body interface{}) {
+	std.output(ctx, SeverityDebug, body, nil)
 }
 
 // Debugf is equivalent to log.StdDebug.Printf()
@@ -118,9 +118,9 @@ func Debugf(ctx context.Context, format string, v ...interface{}) {
 	std.output(ctx, SeverityDebug, fmt.Sprintf(format, v...), nil)
 }
 
-// Info is equivalent to log.StdInfo.Print()
-func Info(ctx context.Context, v ...interface{}) {
-	std.output(ctx, SeverityInfo, fmt.Sprint(v...), nil)
+// Info logs an event body according to the otel definition
+func Info(ctx context.Context, body interface{}) {
+	std.output(ctx, SeverityInfo, body, nil)
 }
 
 // Infof is equivalent to log.StdInfo.Printf()
@@ -128,9 +128,9 @@ func Infof(ctx context.Context, format string, v ...interface{}) {
 	std.output(ctx, SeverityInfo, fmt.Sprintf(format, v...), nil)
 }
 
-// Error is equivalent to log.StdError.Print()
-func Error(ctx context.Context, v ...interface{}) {
-	std.output(ctx, SeverityError, fmt.Sprint(v...), nil)
+// Error logs an event body according to the otel definition
+func Error(ctx context.Context, body interface{}) {
+	std.output(ctx, SeverityError, body, nil)
 }
 
 // Errorf is equivalent to log.StdError.Printf()

--- a/otellog/option.go
+++ b/otellog/option.go
@@ -205,9 +205,9 @@ func WithException(err Exception) *LogBuilder {
 	return ob
 }
 
-// Debug is equivalent to log.StdDebug.Print()
-func (ob *LogBuilder) Debug(ctx context.Context, v ...interface{}) {
-	std.output(ctx, SeverityDebug, fmt.Sprint(v...), ob.options)
+// Debug logs an event body according to the otel definition
+func (ob *LogBuilder) Debug(ctx context.Context, body interface{}) {
+	std.output(ctx, SeverityDebug, body, ob.options)
 }
 
 // Debugf is equivalent to log.StdDebug.Printf()
@@ -215,9 +215,9 @@ func (ob *LogBuilder) Debugf(ctx context.Context, format string, v ...interface{
 	std.output(ctx, SeverityDebug, fmt.Sprintf(format, v...), ob.options)
 }
 
-// Info is equivalent to log.StdInfo.Print()
-func (ob *LogBuilder) Info(ctx context.Context, v ...interface{}) {
-	std.output(ctx, SeverityInfo, fmt.Sprint(v...), ob.options)
+// Info logs an event body according to the otel definition
+func (ob *LogBuilder) Info(ctx context.Context, body interface{}) {
+	std.output(ctx, SeverityInfo, body, ob.options)
 }
 
 // Infof is equivalent to log.StdInfo.Printf()
@@ -225,9 +225,9 @@ func (ob *LogBuilder) Infof(ctx context.Context, format string, v ...interface{}
 	std.output(ctx, SeverityInfo, fmt.Sprintf(format, v...), ob.options)
 }
 
-// Error is equivalent to log.StdError.Print()
-func (ob *LogBuilder) Error(ctx context.Context, v ...interface{}) {
-	std.output(ctx, SeverityError, fmt.Sprint(v...), ob.options)
+// Error logs an event body according to the otel definition
+func (ob *LogBuilder) Error(ctx context.Context, body interface{}) {
+	std.output(ctx, SeverityError, body, ob.options)
 }
 
 // Errorf is equivalent to log.StdError.Printf()

--- a/otellog/option_test.go
+++ b/otellog/option_test.go
@@ -40,28 +40,55 @@ func TestLogMessageWithVisibilityIsFalse_Error_AddVisPropertyAndWritesJSONToBuff
 	rec.OutputShouldBe("{\"time\":\"2022-01-01T01:02:03.000000004Z\",\"sev\":17,\"body\":\"Log message\",\"vis\":0}\n")
 }
 
-func TestLogMessageWithVisibilityIsFalseAndMultipleStringParts_Debug_WritesJSONToBuffer(t *testing.T) {
+func TestLogMessageWithVisibilityIsFalseAndStructAsBody_Debug_WritesJSONToBuffer(t *testing.T) {
 	rec := initializeLogger(t)
+	body := &struct {
+		Id string `json:"id,omitempty"`
+		Toggle bool `json:"toggle,omitempty"`
+		Counter int `json:"counter,omitempty"`
+	}{
+		Id: "id",
+		Toggle: true,
+		Counter: 5,
+	}
 
-	log.WithVisibility(false).Debug(context.Background(), "Log ", "message")
+	log.WithVisibility(false).Debug(context.Background(), body)
 
-	rec.OutputShouldBe("{\"time\":\"2022-01-01T01:02:03.000000004Z\",\"sev\":5,\"body\":\"Log message\",\"vis\":0}\n")
+	rec.OutputShouldBe("{\"time\":\"2022-01-01T01:02:03.000000004Z\",\"sev\":5,\"body\":{\"id\":\"id\",\"toggle\":true,\"counter\":5},\"vis\":0}\n")
 }
 
-func TestLogMessageWithVisibilityIsFalseAndMultipleStringParts_Info_WritesJSONToBuffer(t *testing.T) {
+func TestLogMessageWithVisibilityIsFalseAndStructAsBody_Info_WritesJSONToBuffer(t *testing.T) {
 	rec := initializeLogger(t)
+	body := &struct {
+		Id string `json:"id,omitempty"`
+		Toggle bool `json:"toggle,omitempty"`
+		Counter int `json:"counter,omitempty"`
+	}{
+		Id: "id",
+		Toggle: true,
+		Counter: 5,
+	}
 
-	log.WithVisibility(false).Info(context.Background(), "Log ", "message")
+	log.WithVisibility(false).Info(context.Background(), body)
 
-	rec.OutputShouldBe("{\"time\":\"2022-01-01T01:02:03.000000004Z\",\"sev\":9,\"body\":\"Log message\",\"vis\":0}\n")
+	rec.OutputShouldBe("{\"time\":\"2022-01-01T01:02:03.000000004Z\",\"sev\":9,\"body\":{\"id\":\"id\",\"toggle\":true,\"counter\":5},\"vis\":0}\n")
 }
 
-func TestLogMessageWithVisibilityIsFalseAndMultipleStringParts_Error_WritesJSONToBuffer(t *testing.T) {
+func TestLogMessageWithVisibilityIsFalseAndStructAsBody_Error_WritesJSONToBuffer(t *testing.T) {
 	rec := initializeLogger(t)
+	body := &struct {
+		Id string `json:"id,omitempty"`
+		Toggle bool `json:"toggle,omitempty"`
+		Counter int `json:"counter,omitempty"`
+	}{
+		Id: "id",
+		Toggle: true,
+		Counter: 5,
+	}
 
-	log.WithVisibility(false).Error(context.Background(), "Log ", "message")
+	log.WithVisibility(false).Error(context.Background(), body)
 
-	rec.OutputShouldBe("{\"time\":\"2022-01-01T01:02:03.000000004Z\",\"sev\":17,\"body\":\"Log message\",\"vis\":0}\n")
+	rec.OutputShouldBe("{\"time\":\"2022-01-01T01:02:03.000000004Z\",\"sev\":17,\"body\":{\"id\":\"id\",\"toggle\":true,\"counter\":5},\"vis\":0}\n")
 }
 
 func TestLogMessageWithVisibilityIsFalseAndIsFormatted_Debug_WritesJSONToBuffer(t *testing.T) {


### PR DESCRIPTION
Instead of comma separated values it should be possible to pass a structured body.