### PR TITLE
add warn level to logging

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -74,6 +74,9 @@ var StdDebug = New(os.Stderr, newWriteMessageFunc("DEBUG"))
 // StdInfo is the standard logger for info messages
 var StdInfo = New(os.Stderr, newWriteMessageFunc("INFO"))
 
+// StdWarn is the standard logger for warn messages
+var StdWarn = New(os.Stderr, newWriteMessageFunc("WARN"))
+
 // StdError is the standard logger for error messages
 var StdError = New(os.Stderr, newWriteMessageFunc("ERROR"))
 
@@ -93,7 +96,7 @@ func Debug(ctx context.Context, v ...interface{}) {
 	StdDebug.Print(ctx, v...)
 }
 
-// Debug is equivalent to log.StdDebug.Printf()
+// Debugf is equivalent to log.StdDebug.Printf()
 func Debugf(ctx context.Context, format string, v ...interface{}) {
 	StdDebug.Printf(ctx, format, v...)
 }
@@ -103,9 +106,19 @@ func Info(ctx context.Context, v ...interface{}) {
 	StdInfo.Print(ctx, v...)
 }
 
-// Info is equivalent to log.StdInfo.Printf()
+// Infof is equivalent to log.StdInfo.Printf()
 func Infof(ctx context.Context, format string, v ...interface{}) {
 	StdInfo.Printf(ctx, format, v...)
+}
+
+// Warn is equivalent to log.StdWarn.Print()
+func Warn(ctx context.Context, v ...interface{}) {
+	StdWarn.Print(ctx, v...)
+}
+
+// Warnf is equivalent to log.StdWarn.Printf()
+func Warnf(ctx context.Context, format string, v ...interface{}) {
+	StdWarn.Printf(ctx, format, v...)
 }
 
 // Error is equivalent to log.StdError.Print()
@@ -113,7 +126,7 @@ func Error(ctx context.Context, v ...interface{}) {
 	StdError.Print(ctx, v...)
 }
 
-// Error is equivalent to log.StdError.Printf()
+// Errorf is equivalent to log.StdError.Printf()
 func Errorf(ctx context.Context, format string, v ...interface{}) {
 	StdError.Printf(ctx, format, v...)
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -179,6 +179,32 @@ func TestStdInfoWriteMessageUnchanged_Infof_WritesMessageWithTimestampAndInfo(t 
 	}
 }
 
+func TestStdInfoWriteMessageUnchanged_Warn_WritesMessageWithTimestampAndInfo(t *testing.T) {
+	rec := newOutputRecorder(t)
+	log.StdWarn.SetOutput(rec)
+
+	log.Warn(context.Background(), "Message")
+
+	r, _ := regexp.Compile(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z WARN Message\n`)
+	actual := rec.String()
+	if !r.MatchString(actual) {
+		t.Errorf("'%v' doesn't match the pattern '<RFC3339 Timestamp> WARN Message\n'", actual)
+	}
+}
+
+func TestStdInfoWriteMessageUnchanged_Warnf_WritesMessageWithTimestampAndInfo(t *testing.T) {
+	rec := newOutputRecorder(t)
+	log.StdWarn.SetOutput(rec)
+
+	log.Warnf(context.Background(), "Message %v", 1)
+
+	r, _ := regexp.Compile(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z WARN Message 1\n`)
+	actual := rec.String()
+	if !r.MatchString(actual) {
+		t.Errorf("'%v' doesn't match the pattern '<RFC3339 Timestamp> WARN Message\n'", actual)
+	}
+}
+
 func TestStdInfoWriteMessageUnchanged_Error_WritesMessageWithTimestampAndInfo(t *testing.T) {
 	rec := newOutputRecorder(t)
 	log.StdError.SetOutput(rec)

--- a/log/syslog/syslog.go
+++ b/log/syslog/syslog.go
@@ -17,6 +17,7 @@ import (
 
 const DEBUG = 7
 const INFO = 6
+const WARN = 4
 const ERROR = 3
 
 // NewWriter creates a new syslogwriter which writes to the given endpoint

--- a/log/syslog/syslog_test.go
+++ b/log/syslog/syslog_test.go
@@ -41,10 +41,31 @@ func TestWriteHeaderDebugFunc_WritesAppnameAndDebugSeverity(t *testing.T) {
 	// Priority value is calculated as follows
 	// FACILITY * 8 + SEVERITY
 	// FACILITY is 16 (local use 0)
-	// SEVERITY is 7 (Info)
+	// SEVERITY is 7 (Debug)
 	// 16*8+7=135
 	// https://tools.ietf.org/html/rfc5424#section-6.2.1
 	regex := fmt.Sprintf(`<135>1 \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z %v myapp %v - `, hostname, os.Getpid())
+	r, _ := regexp.Compile(regex)
+	actual := string(buf)
+	if !r.MatchString(actual) {
+		t.Errorf("\n'%v' doesn't match the pattern\n'%v'", actual, regex)
+	}
+}
+
+func TestWriteHeaderDebugFunc_WritesAppnameAndWarnSeverity(t *testing.T) {
+	f := syslog.NewWriteHeaderFunc("myapp", syslog.WARN)
+
+	var buf []byte
+	buf = f(context.Background(), buf, "message")
+
+	hostname, _ := os.Hostname()
+	// Priority value is calculated as follows
+	// FACILITY * 8 + SEVERITY
+	// FACILITY is 16 (local use 0)
+	// SEVERITY is 4 (Warn)
+	// 16*8+4=132
+	// https://tools.ietf.org/html/rfc5424#section-6.2.1
+	regex := fmt.Sprintf(`<132>1 \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z %v myapp %v - `, hostname, os.Getpid())
 	r, _ := regexp.Compile(regex)
 	actual := string(buf)
 	if !r.MatchString(actual) {
@@ -62,7 +83,7 @@ func TestWriteHeaderDebugFunc_WritesAppnameAndErrorSeverity(t *testing.T) {
 	// Priority value is calculated as follows
 	// FACILITY * 8 + SEVERITY
 	// FACILITY is 16 (local use 0)
-	// SEVERITY is 3 (Info)
+	// SEVERITY is 3 (Error)
 	// 16*8+3=131
 	// https://tools.ietf.org/html/rfc5424#section-6.2.1
 	regex := fmt.Sprintf(`<131>1 \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z %v myapp %v - `, hostname, os.Getpid())


### PR DESCRIPTION
The changes add the warn log level, according to [RFC 5424](https://tools.ietf.org/html/rfc5424#section-6.2.1). Also fixed minor typos in the comments.