### PR TITLE
Handle 403 response from IDP with nil principal and nil error instead…

### DIFF
--- a/idp/idpclient/client.go
+++ b/idp/idpclient/client.go
@@ -54,8 +54,8 @@ func PrincipalCache(pc Cache) Option {
 
 // New creates a new Client for the IdentityProvider-App using the following defaults:
 //
-//	• HttpClient: http.DefaultClient
-//	• principalCache: An internal implementation is used
+//   - HttpClient: http.DefaultClient
+//   - principalCache: An internal implementation is used
 //
 // If you don't want to use the defaults provide one or more options to this function.
 func New(options ...Option) (*client, error) {
@@ -150,7 +150,7 @@ func (c *client) Validate(ctx context.Context, systemBaseUri string, tenantId st
 			c.principalCache.Set(cacheKey, p, validFor)
 		}
 		return &p, nil
-	case http.StatusUnauthorized:
+	case http.StatusUnauthorized, http.StatusForbidden:
 		_, _ = ioutil.ReadAll(resp.Body) // client must read to EOF and close body cf. https://godoc.org/net/http#Client
 		return nil, nil
 	default:
@@ -166,7 +166,6 @@ The authSessionId is used to authorize the request.
 
 If the user exists, a none nil *scim.Principal is returned.
 Otherwise the returned *scim.Principal is nil.
-
 */
 func (c *client) GetPrincipalById(ctx context.Context, systemBaseUri string, tenantId string, authSessionId string, principalId string) (*scim.Principal, error) {
 	// tenantid not used so far but included to implement a cache without changing the method signature

--- a/idp/idpclient/client_test.go
+++ b/idp/idpclient/client_test.go
@@ -440,7 +440,7 @@ func TestIdpReturnsUnexpectedStatusCode_GetPrincipalById_ReturnsError(t *testing
 	}
 }
 
-func TestIdpReturns403WithEmptyResponseMsg_Validate_ReturnsNil(t *testing.T) {
+func TestIdpReturnsForbiddenWithEmptyResponseMsg_Validate_ReturnsNil(t *testing.T) {
 	idpStub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "max-age=1600, private")
 		w.Header().Set("Content-Type", "application/hal+json; charset=utf-8")

--- a/idp/idpclient/client_test.go
+++ b/idp/idpclient/client_test.go
@@ -410,7 +410,7 @@ func TestCallerIsAuthorizedAndPrincipalDoesntExist_GetPrincipalById_ReturnsNil(t
 	}
 
 	if got != nil {
-		t.Errorf("expected principal value nil, got %v ",got)
+		t.Errorf("expected principal value nil, got %v ", got)
 	}
 }
 
@@ -440,11 +440,28 @@ func TestIdpReturnsUnexpectedStatusCode_GetPrincipalById_ReturnsError(t *testing
 	}
 }
 
-func TestNonExplicitHandledReturnCodeWithEmptyResponseMsg_Validate_ReturnsError(t *testing.T) {
+func TestIdpReturns403WithEmptyResponseMsg_Validate_ReturnsNil(t *testing.T) {
 	idpStub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "max-age=1600, private")
 		w.Header().Set("Content-Type", "application/hal+json; charset=utf-8")
 		w.WriteHeader(403)
+		w.Write([]byte(""))
+		return
+	}))
+	defer idpStub.Close()
+
+	got, err := defaultClient.Validate(context.Background(), idpStub.URL, "1", invalidAuthSessionId)
+
+	if err != nil || got != nil {
+		t.Error("expects principal value nil and nil error")
+	}
+}
+
+func TestNonExplicitHandledReturnCodeWithEmptyResponseMsg_Validate_ReturnsError(t *testing.T) {
+	idpStub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "max-age=1600, private")
+		w.Header().Set("Content-Type", "application/hal+json; charset=utf-8")
+		w.WriteHeader(410)
 		w.Write([]byte(""))
 		return
 	}))


### PR DESCRIPTION
… of returning an error

Currently the SDK returns an error if the IDP answers with a Forbidden to a call via Validate(). Instead of logging an returning an unexpected error.