### PR TITLE
changed behaviour with empty log body

### DIFF
--- a/otellog/log.go
+++ b/otellog/log.go
@@ -71,12 +71,17 @@ func (l *Logger) output(ctx context.Context, sev Severity, msg interface{}, opti
 	}
 
 	s, err := l.outputFormatter(&e)
-	if err == nil {
-		if len(s) == 0 || s[len(s)-1] != '\n' {
-			s = append(s, '\n')
-		}
-		l.out.Write(s)
+	if err != nil {
+		return
 	}
+	if len(s) == 0 {
+		return
+	}
+
+	if s[len(s)-1] != '\n' {
+		s = append(s, '\n')
+	}
+	l.out.Write(s)
 }
 
 // SetOutput sets the output destination for the logger.

--- a/otellog/log_test.go
+++ b/otellog/log_test.go
@@ -72,12 +72,12 @@ func TestLogMessageWithStructAsBody_SeverityLevel_WritesJSONToBuffer(t *testing.
 		t.Run(sev.name, func(t *testing.T) {
 			rec := initializeLogger(t)
 			body := &struct {
-				Id string `json:"id,omitempty"`
-				Toggle bool `json:"toggle,omitempty"`
-				Counter int `json:"counter,omitempty"`
+				Id      string `json:"id,omitempty"`
+				Toggle  bool   `json:"toggle,omitempty"`
+				Counter int    `json:"counter,omitempty"`
 			}{
-				Id: "id",
-				Toggle: true,
+				Id:      "id",
+				Toggle:  true,
 				Counter: 5,
 			}
 
@@ -126,6 +126,39 @@ func TestLogMessageWithCustomOutputFormatter_Info_WritesCustomFormatToBuffer(t *
 	log.Info(context.Background(), "Log message")
 
 	rec.OutputShouldBe("This is a Log message with severity level 9.\n")
+}
+
+func TestLogCustomOutputFormatterReturnsError_Info_WritesCustomFormatToBuffer(t *testing.T) {
+	rec := initializeLogger(t)
+	log.SetOutputFormatter(func(e *log.Event) ([]byte, error) {
+		return nil, fmt.Errorf("error")
+	})
+
+	log.Info(context.Background(), "Log message")
+
+	rec.OutputShouldBe("")
+}
+
+func TestLogCustomOutputFormatterReturnsEmptyString_Info_WritesCustomFormatToBuffer(t *testing.T) {
+	rec := initializeLogger(t)
+	log.SetOutputFormatter(func(e *log.Event) ([]byte, error) {
+		return []byte(""), nil
+	})
+
+	log.Info(context.Background(), "Log message")
+
+	rec.OutputShouldBe("")
+}
+
+func TestLogCustomOutputFormatterReturnsStringNil_Info_WritesCustomFormatToBuffer(t *testing.T) {
+	rec := initializeLogger(t)
+	log.SetOutputFormatter(func(e *log.Event) ([]byte, error) {
+		return nil, nil
+	})
+
+	log.Info(context.Background(), "Log message")
+
+	rec.OutputShouldBe("")
 }
 
 func TestSeveralLogMessagesAtTheSameTime_Info_WritesJSONToBuffer(t *testing.T) {


### PR DESCRIPTION
before: logs empty line if outputformatter returns nil or empty string.
now: does not log anything if outputformatter returns nil or empty string.