### PR TITLE
fix(mediatype): avoid panic on malformed Accept header values

### DIFF
--- a/contentnegotiation/mediatype/mediatype.go
+++ b/contentnegotiation/mediatype/mediatype.go
@@ -28,6 +28,7 @@ type Mediatype struct {
 // It returns the negotiated mediatype or an error if none of the requested mediatypes is supported.
 //
 // Example:
+//
 //	func handler(w http.ResponseWriter, req *http.Request) {
 //		negotiatedType, err := mediatype.Negotiate(req.Header.Get("Accept"), []string{"text/html","application/json"})
 //		if err != nil {
@@ -53,11 +54,19 @@ func Negotiate(acceptHeader string, supportedTypes []string) (*Mediatype, error)
 	}
 
 	tokens := strings.Split(acceptHeader, ",")
-	mediaranges := make([]*headervalue, len(tokens))
-	for k, r := range tokens {
-		x, _ := parseHeaderValue(r)
-		mediaranges[k] = x
+	mediaranges := make([]*headervalue, 0, len(tokens))
+	for _, r := range tokens {
+		x, err := parseHeaderValue(r)
+		if err != nil || x == nil {
+			continue
+		}
+		mediaranges = append(mediaranges, x)
 	}
+
+	if len(mediaranges) == 0 {
+		return nil, ErrNotSupported
+	}
+
 	sort.Sort(sort.Reverse(headervalues(mediaranges)))
 
 	for _, mr := range mediaranges {

--- a/contentnegotiation/mediatype/mediatype_test.go
+++ b/contentnegotiation/mediatype/mediatype_test.go
@@ -19,6 +19,7 @@ func TestEmptyAcceptHeaderAndSupportedTypesIsEmpty_ReturnsErrorNotSupported(t *t
 
 func TestInvalidAcceptHeader_ReturnsErrorNotSupported(t *testing.T) {
 	(&negotiateWith{acceptHeader: "*/", supportedTypes: []string{"text/html"}}).shouldReturnErrorNotSupported(t)
+	(&negotiateWith{acceptHeader: " ", supportedTypes: []string{"text/html"}}).shouldReturnErrorNotSupported(t)
 }
 
 func TestEmptyAcceptHeaderAndSupportedTypesHasOneElement_ReturnsSupportedType(t *testing.T) {


### PR DESCRIPTION
## What

Fixes a panic in `contentnegotiation/mediatype` when the `Accept` header contains malformed values (e.g. `" "`).

## Why

`Negotiate` parsed comma-separated `Accept` tokens and appended parse results directly to `mediaranges`.
For malformed tokens, parsing could produce invalid entries, which later caused a nil dereference during sorting.

This made malformed input crash instead of returning `ErrNotSupported`.

## Changes

- In `contentnegotiation/mediatype/mediatype.go`:
  - Parse `Accept` tokens into a preallocated slice.
  - Skip tokens where `parseHeaderValue` returns an error or `nil`.
  - If no valid media ranges remain, return `ErrNotSupported`.
  - Keep existing negotiation behavior for valid inputs.

## Tests

- Extended `TestInvalidAcceptHeader_ReturnsErrorNotSupported` in
  `contentnegotiation/mediatype/mediatype_test.go` with:
  - `acceptHeader: " "` and `supportedTypes: []string{"text/html"}`
- Existing mediatype tests continue to pass.